### PR TITLE
fix: reduce the number of protocols supported by the enforcer

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -102,7 +102,7 @@ func ValidateNetworkList(attribute string, networks []string) error {
 func ValidateProtocol(attribute string, proto string) error {
 
 	upperProto := strings.ToUpper(proto)
-	if upperProto == protocols.ALL || protocols.L4ProtocolNumberFromName(upperProto) != -1 {
+	if upperProto == protocols.ALL || protocols.SupportedL4ProtocolNumberFromName(upperProto) != -1 {
 		return nil
 	}
 

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -402,6 +402,14 @@ func TestValidateProtocol(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"valid but unsupported protocol",
+			args{
+				"proto",
+				"CRTP",
+			},
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/protocols/protocols.go
+++ b/protocols/protocols.go
@@ -156,6 +156,9 @@ var L4ProtocolNumbers = make([]string, 150)
 // L4ProtocolNames contains the list of all IANA protocols organized by names
 var L4ProtocolNames = map[string]int{}
 
+// SupportedL4Protocols contains the list of all IANA protocols supported by the enforcer.
+var SupportedL4Protocols = map[string]int{}
+
 // init initializes variables
 func init() {
 	L4ProtocolNumbers[0] = L4ProtocolHOPOPT
@@ -437,6 +440,15 @@ func init() {
 		L4ProtocolWESP:           141,
 		L4ProtocolROHC:           142,
 	}
+
+	SupportedL4Protocols = map[string]int{
+		L4ProtocolICMP:   1,
+		L4ProtocolIGMP:   2,
+		L4ProtocolIPinIP: 4,
+		L4ProtocolTCP:    6,
+		L4ProtocolUDP:    17,
+		L4ProtocolGREs:   47,
+	}
 }
 
 // L4ProtocolNameFromNumber returns the IANA name for the given protocol number.
@@ -460,6 +472,15 @@ func L4ProtocolNameFromNumber(n int64) string {
 // L4ProtocolNumberFromName returns the protocol number given a protocol name.
 func L4ProtocolNumberFromName(name string) int {
 	if n, ok := L4ProtocolNames[name]; ok {
+		return n
+	}
+
+	return -1
+}
+
+// SupportedL4ProtocolNumberFromName returns the protocol number for a given protocol name if supported by the enforcer.
+func SupportedL4ProtocolNumberFromName(name string) int {
+	if n, ok := SupportedL4Protocols[name]; ok {
 		return n
 	}
 


### PR DESCRIPTION
Enforcer supports only a subset of all IANA protocols. Protocol number are handled correctly but names must be reduced to:

* IPSEC
* IGMP
* IP-in-IP
* GREs
* UDP
* TCP
* ICMP
* ALL

Updating custom validation and keep the existing IANA protocol for further usage