### PR TITLE
Gaia Remove Kube-squall activation mode and make Pod Atomic as default activation type

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -6581,7 +6581,7 @@ Defines the mode of activation on the KubernetesCluster.
 | Characteristics | Value                                  |
 | -               | -:                                     |
 | Allowed Value   | `KubeSquall, PodAtomic, PodContainers` |
-| Default         | `"KubeSquall"`                         |
+| Default         | `"PodAtomic"`                          |
 | Orderable       | `true`                                 |
 
 #### `adminEmail (string)`

--- a/k8scluster.go
+++ b/k8scluster.go
@@ -193,7 +193,7 @@ func NewK8SCluster() *K8SCluster {
 	return &K8SCluster{
 		ModelVersion:      1,
 		Metadata:          []string{},
-		ActivationType:    K8SClusterActivationTypeKubeSquall,
+		ActivationType:    K8SClusterActivationTypePodAtomic,
 		Annotations:       map[string][]string{},
 		AssociatedTags:    []string{},
 		NetworkPolicyType: K8SClusterNetworkPolicyTypeKubernetes,
@@ -702,7 +702,7 @@ var K8SClusterAttributesMap = map[string]elemental.AttributeSpecification{
 	"ActivationType": elemental.AttributeSpecification{
 		AllowedChoices: []string{"KubeSquall", "PodAtomic", "PodContainers"},
 		ConvertedName:  "ActivationType",
-		DefaultValue:   K8SClusterActivationTypeKubeSquall,
+		DefaultValue:   K8SClusterActivationTypePodAtomic,
 		Description:    `Defines the mode of activation on the KubernetesCluster.`,
 		Exposed:        true,
 		Name:           "activationType",
@@ -976,7 +976,7 @@ var K8SClusterLowerCaseAttributesMap = map[string]elemental.AttributeSpecificati
 	"activationtype": elemental.AttributeSpecification{
 		AllowedChoices: []string{"KubeSquall", "PodAtomic", "PodContainers"},
 		ConvertedName:  "ActivationType",
-		DefaultValue:   K8SClusterActivationTypeKubeSquall,
+		DefaultValue:   K8SClusterActivationTypePodAtomic,
 		Description:    `Defines the mode of activation on the KubernetesCluster.`,
 		Exposed:        true,
 		Name:           "activationType",

--- a/specs/k8scluster.spec
+++ b/specs/k8scluster.spec
@@ -46,7 +46,7 @@ attributes:
     - KubeSquall
     - PodAtomic
     - PodContainers
-    default_value: KubeSquall
+    default_value: PodAtomic
     orderable: true
 
   - name: adminEmail


### PR DESCRIPTION
Remove Kube-squall activation mode and make Pod Atomic as default activation type