### PR TITLE
Make mTLS optional when defining a hook

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -439,20 +439,18 @@ type attrInfo struct {
 //
 // which will return an error because Attr2 was empty and Attr1 was set.
 func validateAllOrNoneAttrGrouping(attrs ...attrInfo) error {
+
 	var missing, provided []string
-	var nonEmptyAttrExists, emptyAttrExists bool
 
 	for _, attr := range attrs {
 		if attr.value == "" {
-			nonEmptyAttrExists = true
 			provided = append(provided, attr.name)
 		} else {
-			emptyAttrExists = true
 			missing = append(missing, attr.name)
 		}
 	}
 
-	if nonEmptyAttrExists && emptyAttrExists {
+	if len(missing) > 0 && len(provided) > 0 {
 		return elemental.NewError(
 			"Validation Error",
 			fmt.Sprintf("Attribute(s) [%s] are required because attribute(s) [%s] were provided", strings.Join(missing, ", "), strings.Join(provided, ", ")),

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -419,6 +419,66 @@ func ValidateHTTPMethods(attribute string, methods []string) error {
 	return nil
 }
 
+type attrInfo struct {
+	name  string
+	value string
+}
+
+// validateAllOrNoneAttrGrouping is a helper used to validate that the provided attributes must either all be provided or not at all
+//
+// for example suppose you have 2 related attributes that are individually optional, but if any of them are
+// provided, then all of them should be provided:
+//
+// 		err := validateAllOrNoneAttrGrouping(attrInfo{
+//				name:  "Attr1",
+//				value: "some value",
+//		}, attrInfo{
+//				name:  "Attr2",
+//				value: "",
+//		})
+//
+// which will return an error because Attr2 was empty and Attr1 was set.
+func validateAllOrNoneAttrGrouping(attrs ...attrInfo) error {
+	var missing, provided []string
+	var nonEmptyAttrExists, emptyAttrExists bool
+
+	for _, attr := range attrs {
+		if attr.value == "" {
+			nonEmptyAttrExists = true
+			provided = append(provided, attr.name)
+		} else {
+			emptyAttrExists = true
+			missing = append(missing, attr.name)
+		}
+	}
+
+	if nonEmptyAttrExists && emptyAttrExists {
+		return elemental.NewError(
+			"Validation Error",
+			fmt.Sprintf("Attribute(s) [%s] are required because attribute(s) [%s] were provided", strings.Join(missing, ", "), strings.Join(provided, ", ")),
+			"elemental",
+			http.StatusUnprocessableEntity)
+	}
+
+	return nil
+}
+
+// ValidateHookPolicy validates the hookpolicy model by checking:
+//
+// • the optional 'clientCertificate' & 'clientCertificateKey'. The validator ensures that if either one of these
+// attributes are provided, then BOTH should be provided even though the attributes are individually optional.
+func ValidateHookPolicy(hp *HookPolicy) error {
+	return validateAllOrNoneAttrGrouping(
+		attrInfo{
+			name:  "clientCertificate",
+			value: hp.ClientCertificate},
+
+		attrInfo{
+			name:  "clientCertificateKey",
+			value: hp.ClientCertificateKey,
+		})
+}
+
 // ValidateHostServices validates a host service. Applies to the new API only.
 func ValidateHostServices(hs *HostService) error {
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -6136,11 +6136,13 @@ the remote endpoint.
 ##### `clientCertificate` `string`
 
 ClientCertificate contains the client certificate that will be used to connect
-to the remote endoint.
+to the remote endpoint. If provided, the private key associated with this certificate must
+also be configured.
 
 ##### `clientCertificateKey` `string`
 
-ClientCertificateKey contains the key associated to the clientCertificate.
+ClientCertificateKey contains the key associated to the clientCertificate. Must be provided only when
+ClientCertificate has been configured.
 
 ##### `continueOnError` `boolean`
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -6161,7 +6161,7 @@ Disabled defines if the propert is disabled.
 
 ##### `endpoint` `string` [`required`]
 
-Endpoint contains the full address of the remote processor endoint.
+Endpoint contains the full address of the remote processor endpoint.
 
 ##### `expirationTime` `time`
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -6128,17 +6128,17 @@ Annotation stores additional information about an entity.
 
 AssociatedTags are the list of tags attached to an entity.
 
-##### `certificateAuthority` `string` [`required`]
+##### `certificateAuthority` `string`
 
 CertificateAuthority contains the pem block of the certificate authority used by
 the remote endpoint.
 
-##### `clientCertificate` `string` [`required`]
+##### `clientCertificate` `string`
 
 ClientCertificate contains the client certificate that will be used to connect
 to the remote endoint.
 
-##### `clientCertificateKey` `string` [`required`]
+##### `clientCertificateKey` `string`
 
 ClientCertificateKey contains the key associated to the clientCertificate.
 

--- a/hookpolicy.go
+++ b/hookpolicy.go
@@ -111,10 +111,12 @@ type HookPolicy struct {
 	CertificateAuthority string `json:"certificateAuthority" msgpack:"certificateAuthority" bson:"certificateauthority" mapstructure:"certificateAuthority,omitempty"`
 
 	// ClientCertificate contains the client certificate that will be used to connect
-	// to the remote endoint.
+	// to the remote endpoint. If provided, the private key associated with this certificate must
+	// also be configured.
 	ClientCertificate string `json:"clientCertificate" msgpack:"clientCertificate" bson:"clientcertificate" mapstructure:"clientCertificate,omitempty"`
 
-	// ClientCertificateKey contains the key associated to the clientCertificate.
+	// ClientCertificateKey contains the key associated to the clientCertificate. Must be provided only when
+	// ClientCertificate has been configured.
 	ClientCertificateKey string `json:"clientCertificateKey" msgpack:"clientCertificateKey" bson:"clientcertificatekey" mapstructure:"clientCertificateKey,omitempty"`
 
 	// If set to true and `+"`"+`mode`+"`"+` is in `+"`"+`Pre`+"`"+`, the request will be honored even if
@@ -891,7 +893,8 @@ the remote endpoint.`,
 		AllowedChoices: []string{},
 		ConvertedName:  "ClientCertificate",
 		Description: `ClientCertificate contains the client certificate that will be used to connect
-to the remote endoint.`,
+to the remote endpoint. If provided, the private key associated with this certificate must
+also be configured.`,
 		Exposed:   true,
 		Name:      "clientCertificate",
 		Orderable: true,
@@ -901,14 +904,15 @@ to the remote endoint.`,
 	"ClientCertificateKey": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "ClientCertificateKey",
-		Description:    `ClientCertificateKey contains the key associated to the clientCertificate.`,
-		Exposed:        true,
-		Name:           "clientCertificateKey",
-		Orderable:      true,
-		Secret:         true,
-		Stored:         true,
-		Transient:      true,
-		Type:           "string",
+		Description: `ClientCertificateKey contains the key associated to the clientCertificate. Must be provided only when
+ClientCertificate has been configured.`,
+		Exposed:   true,
+		Name:      "clientCertificateKey",
+		Orderable: true,
+		Secret:    true,
+		Stored:    true,
+		Transient: true,
+		Type:      "string",
 	},
 	"ContinueOnError": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
@@ -1237,7 +1241,8 @@ the remote endpoint.`,
 		AllowedChoices: []string{},
 		ConvertedName:  "ClientCertificate",
 		Description: `ClientCertificate contains the client certificate that will be used to connect
-to the remote endoint.`,
+to the remote endpoint. If provided, the private key associated with this certificate must
+also be configured.`,
 		Exposed:   true,
 		Name:      "clientCertificate",
 		Orderable: true,
@@ -1247,14 +1252,15 @@ to the remote endoint.`,
 	"clientcertificatekey": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "ClientCertificateKey",
-		Description:    `ClientCertificateKey contains the key associated to the clientCertificate.`,
-		Exposed:        true,
-		Name:           "clientCertificateKey",
-		Orderable:      true,
-		Secret:         true,
-		Stored:         true,
-		Transient:      true,
-		Type:           "string",
+		Description: `ClientCertificateKey contains the key associated to the clientCertificate. Must be provided only when
+ClientCertificate has been configured.`,
+		Exposed:   true,
+		Name:      "clientCertificateKey",
+		Orderable: true,
+		Secret:    true,
+		Stored:    true,
+		Transient: true,
+		Type:      "string",
 	},
 	"continueonerror": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
@@ -1609,10 +1615,12 @@ type SparseHookPolicy struct {
 	CertificateAuthority *string `json:"certificateAuthority,omitempty" msgpack:"certificateAuthority,omitempty" bson:"certificateauthority,omitempty" mapstructure:"certificateAuthority,omitempty"`
 
 	// ClientCertificate contains the client certificate that will be used to connect
-	// to the remote endoint.
+	// to the remote endpoint. If provided, the private key associated with this certificate must
+	// also be configured.
 	ClientCertificate *string `json:"clientCertificate,omitempty" msgpack:"clientCertificate,omitempty" bson:"clientcertificate,omitempty" mapstructure:"clientCertificate,omitempty"`
 
-	// ClientCertificateKey contains the key associated to the clientCertificate.
+	// ClientCertificateKey contains the key associated to the clientCertificate. Must be provided only when
+	// ClientCertificate has been configured.
 	ClientCertificateKey *string `json:"clientCertificateKey,omitempty" msgpack:"clientCertificateKey,omitempty" bson:"clientcertificatekey,omitempty" mapstructure:"clientCertificateKey,omitempty"`
 
 	// If set to true and `+"`"+`mode`+"`"+` is in `+"`"+`Pre`+"`"+`, the request will be honored even if

--- a/hookpolicy.go
+++ b/hookpolicy.go
@@ -133,7 +133,7 @@ type HookPolicy struct {
 	// Disabled defines if the propert is disabled.
 	Disabled bool `json:"disabled" msgpack:"disabled" bson:"disabled" mapstructure:"disabled,omitempty"`
 
-	// Endpoint contains the full address of the remote processor endoint.
+	// Endpoint contains the full address of the remote processor endpoint.
 	Endpoint string `json:"endpoint" msgpack:"endpoint" bson:"endpoint" mapstructure:"endpoint,omitempty"`
 
 	// If set the policy will be auto deleted after the given time.
@@ -969,7 +969,7 @@ calling the hook fails.`,
 	"Endpoint": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "Endpoint",
-		Description:    `Endpoint contains the full address of the remote processor endoint.`,
+		Description:    `Endpoint contains the full address of the remote processor endpoint.`,
 		Exposed:        true,
 		Name:           "endpoint",
 		Orderable:      true,
@@ -1315,7 +1315,7 @@ calling the hook fails.`,
 	"endpoint": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "Endpoint",
-		Description:    `Endpoint contains the full address of the remote processor endoint.`,
+		Description:    `Endpoint contains the full address of the remote processor endpoint.`,
 		Exposed:        true,
 		Name:           "endpoint",
 		Orderable:      true,
@@ -1626,7 +1626,7 @@ type SparseHookPolicy struct {
 	// Disabled defines if the propert is disabled.
 	Disabled *bool `json:"disabled,omitempty" msgpack:"disabled,omitempty" bson:"disabled,omitempty" mapstructure:"disabled,omitempty"`
 
-	// Endpoint contains the full address of the remote processor endoint.
+	// Endpoint contains the full address of the remote processor endpoint.
 	Endpoint *string `json:"endpoint,omitempty" msgpack:"endpoint,omitempty" bson:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
 
 	// If set the policy will be auto deleted after the given time.

--- a/hookpolicy.go
+++ b/hookpolicy.go
@@ -739,6 +739,11 @@ func (o *HookPolicy) Validate() error {
 		errors = errors.Append(err)
 	}
 
+	// Custom object validation.
+	if err := ValidateHookPolicy(o); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if len(requiredErrors) > 0 {
 		return requiredErrors
 	}

--- a/hookpolicy.go
+++ b/hookpolicy.go
@@ -703,16 +703,8 @@ func (o *HookPolicy) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateRequiredString("certificateAuthority", o.CertificateAuthority); err != nil {
-		requiredErrors = requiredErrors.Append(err)
-	}
-
 	if err := ValidatePEM("certificateAuthority", o.CertificateAuthority); err != nil {
 		errors = errors.Append(err)
-	}
-
-	if err := elemental.ValidateRequiredString("clientCertificate", o.ClientCertificate); err != nil {
-		requiredErrors = requiredErrors.Append(err)
 	}
 
 	if err := ValidatePEM("clientCertificate", o.ClientCertificate); err != nil {
@@ -887,7 +879,6 @@ the remote endpoint.`,
 		Exposed:   true,
 		Name:      "certificateAuthority",
 		Orderable: true,
-		Required:  true,
 		Stored:    true,
 		Type:      "string",
 	},
@@ -899,7 +890,6 @@ to the remote endoint.`,
 		Exposed:   true,
 		Name:      "clientCertificate",
 		Orderable: true,
-		Required:  true,
 		Stored:    true,
 		Type:      "string",
 	},
@@ -910,7 +900,6 @@ to the remote endoint.`,
 		Exposed:        true,
 		Name:           "clientCertificateKey",
 		Orderable:      true,
-		Required:       true,
 		Secret:         true,
 		Stored:         true,
 		Transient:      true,
@@ -1236,7 +1225,6 @@ the remote endpoint.`,
 		Exposed:   true,
 		Name:      "certificateAuthority",
 		Orderable: true,
-		Required:  true,
 		Stored:    true,
 		Type:      "string",
 	},
@@ -1248,7 +1236,6 @@ to the remote endoint.`,
 		Exposed:   true,
 		Name:      "clientCertificate",
 		Orderable: true,
-		Required:  true,
 		Stored:    true,
 		Type:      "string",
 	},
@@ -1259,7 +1246,6 @@ to the remote endoint.`,
 		Exposed:        true,
 		Name:           "clientCertificateKey",
 		Orderable:      true,
-		Required:       true,
 		Secret:         true,
 		Stored:         true,
 		Transient:      true,

--- a/specs/_validation.mapping
+++ b/specs/_validation.mapping
@@ -6,6 +6,10 @@ $enforcerprofile:
   elemental:
     name: ValidateEnforcerProfile
 
+$hookpolicies:
+  elemental:
+    name: ValidateHookPolicy
+
 $hostservices:
   elemental:
     name: ValidateHostServices

--- a/specs/hookpolicy.spec
+++ b/specs/hookpolicy.spec
@@ -34,6 +34,8 @@ model:
   - '@fallback'
   - '@zonable'
   - '@timeable'
+  validations:
+  - $hookpolicies
 
 # Indexes
 indexes:

--- a/specs/hookpolicy.spec
+++ b/specs/hookpolicy.spec
@@ -49,7 +49,6 @@ attributes:
     type: string
     exposed: true
     stored: true
-    required: true
     example_value: |-
       -----BEGIN CERTIFICATE-----
       MIIBbjCCARSgAwIBAgIRANRbvVzTzBZOvMCb8BiKCLowCgYIKoZIzj0EAwIwJjEN
@@ -72,7 +71,6 @@ attributes:
     type: string
     exposed: true
     stored: true
-    required: true
     example_value: |-
       -----BEGIN CERTIFICATE-----
       MIIBczCCARigAwIBAgIRALD3Vz81Pq10g7n4eAkOsCYwCgYIKoZIzj0EAwIwJjEN
@@ -93,7 +91,6 @@ attributes:
     type: string
     exposed: true
     stored: true
-    required: true
     example_value: |-
       -----BEGIN EC PRIVATE KEY-----
       MHcCAQEEIGOXJI/123456789oamOu4tQAIKFdbyvkIJg9GME0mHzoAoGCCqGSM49

--- a/specs/hookpolicy.spec
+++ b/specs/hookpolicy.spec
@@ -69,7 +69,9 @@ attributes:
   - name: clientCertificate
     description: |-
       ClientCertificate contains the client certificate that will be used to connect
-      to the remote endoint.
+      to the remote endpoint. If provided, the private key associated with this
+      certificate must
+      also be configured.
     type: string
     exposed: true
     stored: true
@@ -89,7 +91,10 @@ attributes:
     - $pem
 
   - name: clientCertificateKey
-    description: ClientCertificateKey contains the key associated to the clientCertificate.
+    description: |-
+      ClientCertificateKey contains the key associated to the clientCertificate. Must
+      be provided only when
+      ClientCertificate has been configured.
     type: string
     exposed: true
     stored: true

--- a/specs/hookpolicy.spec
+++ b/specs/hookpolicy.spec
@@ -112,7 +112,7 @@ attributes:
     stored: true
 
   - name: endpoint
-    description: Endpoint contains the full address of the remote processor endoint.
+    description: Endpoint contains the full address of the remote processor endpoint.
     type: string
     exposed: true
     stored: true


### PR DESCRIPTION
**Issue:** https://github.com/aporeto-inc/aporeto/issues/1274

**Context:** when creating a hook, we want to relax the requirement that mTLS must be configured.

This PR makes the destination endpoint TLS configuration optional and adds a custom validator on the model to validate the optional attributes of `clientCertificate` & `clientCertificateKey`. The validator ensures that **if either one of these attributes are provided, then BOTH must be provided** even though the attributes are individually optional. In the event that a validation error is encountered, an elemental error is thrown which provides the user-agent with context on which attributes were provided and missing.

#### TODO: 
- [x] Get early feedback from Chris & Antoine to see if I am headed in the right direction
- [x] Unit tests for custom validator
