### PR TITLE
fix: add unknown operational status

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1406,7 +1406,7 @@ Namespace tag attached to an entity.
 
 NormalizedTags contains the list of normalized tags of the entities.
 
-##### `operationalStatus` `emum(Registered | Connected | Disconnected | Initialized)`
+##### `operationalStatus` `emum(Registered | Connected | Disconnected | Initialized | Unknown)`
 
 OperationalStatus tells the status of the enforcer.
 

--- a/enforcer.go
+++ b/enforcer.go
@@ -37,6 +37,9 @@ const (
 
 	// EnforcerOperationalStatusRegistered represents the value Registered.
 	EnforcerOperationalStatusRegistered EnforcerOperationalStatusValue = "Registered"
+
+	// EnforcerOperationalStatusUnknown represents the value Unknown.
+	EnforcerOperationalStatusUnknown EnforcerOperationalStatusValue = "Unknown"
 )
 
 // EnforcerIdentity represents the Identity of the object.
@@ -765,7 +768,7 @@ func (o *Enforcer) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("operationalStatus", string(o.OperationalStatus), []string{"Registered", "Connected", "Disconnected", "Initialized"}, false); err != nil {
+	if err := elemental.ValidateStringInList("operationalStatus", string(o.OperationalStatus), []string{"Registered", "Connected", "Disconnected", "Initialized", "Unknown"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -1181,7 +1184,7 @@ with the '@' prefix, and should only be used by external systems.`,
 		Type:           "list",
 	},
 	"OperationalStatus": elemental.AttributeSpecification{
-		AllowedChoices: []string{"Registered", "Connected", "Disconnected", "Initialized"},
+		AllowedChoices: []string{"Registered", "Connected", "Disconnected", "Initialized", "Unknown"},
 		ConvertedName:  "OperationalStatus",
 		DefaultValue:   EnforcerOperationalStatusRegistered,
 		Description:    `OperationalStatus tells the status of the enforcer.`,
@@ -1606,7 +1609,7 @@ with the '@' prefix, and should only be used by external systems.`,
 		Type:           "list",
 	},
 	"operationalstatus": elemental.AttributeSpecification{
-		AllowedChoices: []string{"Registered", "Connected", "Disconnected", "Initialized"},
+		AllowedChoices: []string{"Registered", "Connected", "Disconnected", "Initialized", "Unknown"},
 		ConvertedName:  "OperationalStatus",
 		DefaultValue:   EnforcerOperationalStatusRegistered,
 		Description:    `OperationalStatus tells the status of the enforcer.`,

--- a/specs/enforcer.spec
+++ b/specs/enforcer.spec
@@ -187,6 +187,7 @@ attributes:
     - Connected
     - Disconnected
     - Initialized
+    - Unknown
     default_value: Registered
     filterable: true
 


### PR DESCRIPTION
Status `Unknown` is missing