### PR TITLE
fix: do not store scopes in the database anymore

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -22,7 +22,7 @@ type Endpoint struct {
 	Public bool `json:"public" msgpack:"public" bson:"public" mapstructure:"public,omitempty"`
 
 	// Scopes is deprecated.
-	Scopes []string `json:"scopes" msgpack:"scopes" bson:"scopes" mapstructure:"scopes,omitempty"`
+	Scopes []string `json:"scopes" msgpack:"scopes" bson:"-" mapstructure:"scopes,omitempty"`
 
 	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
 }

--- a/specs/+endpoint.spec
+++ b/specs/+endpoint.spec
@@ -45,7 +45,6 @@ attributes:
     type: list
     exposed: true
     subtype: string
-    stored: true
     read_only: true
     deprecated: true
     orderable: true


### PR DESCRIPTION
Prior 3.5, we were using `scopes` in httpresourcespec files.
After 3.5, we moved to `allowedScopes` and keep the backward compatibility.

Storing the `scopes` property in the database is showing wrong Audit Logs that might be confusing.
For now, we still want to expose the `scopes` that are computed based on `allowedScopes`.

However, storing this property is no longer necessary.

> Reference: https://github.com/aporeto-inc/aporeto/issues/1377