### PR TITLE
fix: do not store scopes in the database anymore

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -22,7 +22,7 @@ type Endpoint struct {
 	Public bool `json:"public" msgpack:"public" bson:"public" mapstructure:"public,omitempty"`
 
 	// Scopes is deprecated.
-	Scopes []string `json:"scopes" msgpack:"scopes" bson:"scopes" mapstructure:"scopes,omitempty"`
+	Scopes []string `json:"scopes" msgpack:"scopes" bson:"-" mapstructure:"scopes,omitempty"`
 
 	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
 }

--- a/specs/+endpoint.spec
+++ b/specs/+endpoint.spec
@@ -45,7 +45,6 @@ attributes:
     type: list
     exposed: true
     subtype: string
-    stored: true
     read_only: true
     deprecated: true
     orderable: true


### PR DESCRIPTION
Same as https://github.com/aporeto-inc/gaia/pull/323 for release 3.9.0 branch