### PR TITLE
Add a standard value for default audit profiles

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -183,6 +183,10 @@ const (
 
 	// StatsTagKeyClaimsID represents claims ID for the flow
 	StatsTagKeyClaimsID = "@claimid"
+
+	// StatsTagValueAuditSystemDefault is the default value for system default
+	// audit rules
+	StatsTagValueAuditSystemDefault = "system-audit"
 )
 
 // Shared Policy constants


### PR DESCRIPTION
Adds a standard default audit profile reporting audit violations based on rules set by
the OS or users directly on Linux. 

This is mainly needed for wrapped hosts.
