### PR TITLE
new: add new webhook trigger type to automations

### DIFF
--- a/automation.go
+++ b/automation.go
@@ -20,6 +20,9 @@ const (
 
 	// AutomationTriggerTime represents the value Time.
 	AutomationTriggerTime AutomationTriggerValue = "Time"
+
+	// AutomationTriggerWebhook represents the value Webhook.
+	AutomationTriggerWebhook AutomationTriggerValue = "Webhook"
 )
 
 // AutomationIdentity represents the Identity of the object.
@@ -672,7 +675,12 @@ func (o *Automation) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("trigger", string(o.Trigger), []string{"Event", "RemoteCall", "Time"}, false); err != nil {
+	if err := elemental.ValidateStringInList("trigger", string(o.Trigger), []string{"Event", "RemoteCall", "Webhook", "Time"}, false); err != nil {
+		errors = errors.Append(err)
+	}
+
+	// Custom object validation.
+	if err := ValidateAutomation(o); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -1048,7 +1056,7 @@ authentication. It will be visible only after creation.`,
 		Type:           "boolean",
 	},
 	"Trigger": elemental.AttributeSpecification{
-		AllowedChoices: []string{"Event", "RemoteCall", "Time"},
+		AllowedChoices: []string{"Event", "RemoteCall", "Webhook", "Time"},
 		ConvertedName:  "Trigger",
 		DefaultValue:   AutomationTriggerTime,
 		Description:    `Controls when the automation should be triggered.`,
@@ -1390,7 +1398,7 @@ authentication. It will be visible only after creation.`,
 		Type:           "boolean",
 	},
 	"trigger": elemental.AttributeSpecification{
-		AllowedChoices: []string{"Event", "RemoteCall", "Time"},
+		AllowedChoices: []string{"Event", "RemoteCall", "Webhook", "Time"},
 		ConvertedName:  "Trigger",
 		DefaultValue:   AutomationTriggerTime,
 		Description:    `Controls when the automation should be triggered.`,

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -423,13 +423,13 @@ func ValidateHTTPMethods(attribute string, methods []string) error {
 func ValidateAutomation(auto *Automation) error {
 	switch auto.Trigger {
 	case AutomationTriggerWebhook:
-			switch len(auto.Actions) {
-			case 1:
-			case 0:
-				return makeValidationError("trigger", "Exactly one action must be defined if trigger type is set to \"Webhook\".")
-			default:
-				return makeValidationError("trigger", "Only one action can be defined if trigger type is set to \"Webhook\".")
-			}
+		switch len(auto.Actions) {
+		case 1:
+		case 0:
+			return makeValidationError("trigger", "Exactly one action must be defined if trigger type is set to \"Webhook\".")
+		default:
+			return makeValidationError("trigger", "Only one action can be defined if trigger type is set to \"Webhook\".")
+		}
 	}
 
 	return nil

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -419,6 +419,22 @@ func ValidateHTTPMethods(attribute string, methods []string) error {
 	return nil
 }
 
+// ValidateAutomation validates an automation
+func ValidateAutomation(auto *Automation) error {
+	switch auto.Trigger {
+	case AutomationTriggerWebhook:
+			switch len(auto.Actions) {
+			case 1:
+			case 0:
+				return makeValidationError("trigger", "Exactly one action must be defined if trigger type is set to \"Webhook\".")
+			default:
+				return makeValidationError("trigger", "Only one action can be defined if trigger type is set to \"Webhook\".")
+			}
+	}
+
+	return nil
+}
+
 // ValidateHostServices validates a host service. Applies to the new API only.
 func ValidateHostServices(hs *HostService) error {
 

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -426,9 +426,9 @@ func ValidateAutomation(auto *Automation) error {
 		switch len(auto.Actions) {
 		case 1:
 		case 0:
-			return makeValidationError("trigger", "Exactly one action must be defined if trigger type is set to \"Webhook\".")
+			return makeValidationError("trigger", fmt.Sprintf("Exactly one action must be defined if trigger type is set to \"%s\".", AutomationTriggerWebhook))
 		default:
-			return makeValidationError("trigger", "Only one action can be defined if trigger type is set to \"Webhook\".")
+			return makeValidationError("trigger", fmt.Sprintf("Only one action can be defined if trigger type is set to \"%s\".", AutomationTriggerWebhook))
 		}
 	}
 

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -1,7 +1,10 @@
 package gaia
 
 import (
+	"net/http"
 	"testing"
+
+	"go.aporeto.io/elemental"
 )
 
 func TestValidatePortString(t *testing.T) {
@@ -904,6 +907,82 @@ func TestValidateOptionalNetworkList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateOptionalNetworkList(tt.args.attribute, tt.args.networks); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateOptionalNetworkList() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAutomation(t *testing.T) {
+	testCases := []struct {
+		scenario    string
+		automation  *Automation
+		shouldError bool
+	}{
+		{
+			scenario: "should not return an error if trigger type is not webhook and multiple actions have been defined",
+			automation: &Automation{
+				Trigger: AutomationTriggerRemoteCall,
+				Actions: []string{
+					"Action 1",
+					"Action 2",
+				},
+			},
+			shouldError: false,
+		},
+		{
+			scenario: "should not return an error if trigger type is webhook and one action has been defined",
+			automation: &Automation{
+				Trigger: AutomationTriggerWebhook,
+				Actions: []string{
+					"Action 1",
+				},
+			},
+			shouldError: false,
+		},
+		{
+			scenario: "should return an error if trigger type is set to webhook and more than one action has been defined",
+			automation: &Automation{
+				Trigger: AutomationTriggerWebhook,
+				Actions: []string{
+					"Action 1",
+					"Action 2",
+				},
+			},
+			shouldError: true,
+		},
+		{
+			scenario: "should return an error if trigger type is set to webhook and no actions have been defined",
+			automation: &Automation{
+				Trigger:     AutomationTriggerWebhook,
+				Actions:     nil,
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			err := ValidateAutomation(tc.automation)
+			switch {
+			case err != nil && tc.shouldError:
+
+				ee, ok := err.(elemental.Error)
+				if !ok {
+					t.Fatalf("error could not be asserted to type \"elemental.Error\"")
+				}
+
+				if ee.Code != http.StatusUnprocessableEntity {
+					t.Errorf("expected elemental error code to be 422, but got %d", ee.Code)
+				}
+
+				if ee.Title != "Validation Error" {
+					t.Errorf("expected elemental error code to be 'Validation Error', but got %s", ee.Title)
+				}
+
+			case err != nil && !tc.shouldError:
+				t.Fatalf("did not expect to get an error, but received: %+v", err)
+			case err == nil && tc.shouldError:
+				t.Fatalf("expected to get an error, but got nothing")
 			}
 		})
 	}

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -953,8 +953,8 @@ func TestValidateAutomation(t *testing.T) {
 		{
 			scenario: "should return an error if trigger type is set to webhook and no actions have been defined",
 			automation: &Automation{
-				Trigger:     AutomationTriggerWebhook,
-				Actions:     nil,
+				Trigger: AutomationTriggerWebhook,
+				Actions: nil,
 			},
 			shouldError: true,
 		},

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -4344,7 +4344,7 @@ authentication. It will be visible only after creation.
 
 If set to `true` a new token will be issued and the previous one invalidated.
 
-##### `trigger` `emum(Event | RemoteCall | Time)`
+##### `trigger` `emum(Event | RemoteCall | Webhook | Time)`
 
 Controls when the automation should be triggered.
 

--- a/specs/_validation.mapping
+++ b/specs/_validation.mapping
@@ -2,6 +2,10 @@ $audience:
   elemental:
     name: ValidateAudience
 
+$automations:
+  elemental:
+    name: ValidateAutomation
+
 $enforcerprofile:
   elemental:
     name: ValidateEnforcerProfile

--- a/specs/automation.spec
+++ b/specs/automation.spec
@@ -28,6 +28,8 @@ model:
   - '@identifiable-stored'
   - '@named'
   - '@timeable'
+  validations:
+  - $automations
 
 # Attributes
 attributes:
@@ -137,6 +139,7 @@ attributes:
     allowed_choices:
     - Event
     - RemoteCall
+    - Webhook
     - Time
     default_value: Time
     orderable: true


### PR DESCRIPTION
### Parent issue: https://github.com/aporeto-inc/aporeto/issues/1274
> the never ending issue :D

### Context

Now with all the recent changes to Bahamut, a NATS pubsub client can choose their desired response mode for their publication and subsequently a subscriber has the ability to respond back accordingly based upon the publishers desired response mode! This is all a fancy way of saying that you can now achieve "request/reply" semantics using the APIs exposed by our Bahamut package. To take advantage of the request/reply pattern, this PR adds a new trigger type to automations known as `Webhook` (_great name, I know!_).

When triggered, the behavioural difference will be that the **HTTP call will block until the actions have executed** . There must be **one (_and only one_) action** defined if this trigger type is used because the Javascript object returned by that action will be used to respond back to the HTTP request. Hence the name `Webhook`. If you haven't guessed, this will basically allow customers to use automations to respond to (Aporeto) webhooks ✨ 

All the backend plumbing to actually consume this trigger will be coming up in subsequent PRs, but this can be shipped without breaking anything.

### Checklist

- [x] Get feedback from Antoine & Chris
- [x] Add unit tests 




