### PR TITLE
fix: allow upto 128 characters for hostservice name

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -243,8 +243,6 @@ func makeValidationError(attribute string, message string) elemental.Error {
 	return err
 }
 
-var regHostServiceName = regexp.MustCompile(`^[a-zA-Z0-9_]{0,11}$`)
-
 // ValidateEnforcerProfile validates a an enforcer profile.
 func ValidateEnforcerProfile(enforcerProfile *EnforcerProfile) error {
 
@@ -435,12 +433,14 @@ func ValidateAutomation(auto *Automation) error {
 	return nil
 }
 
+var regHostServiceName = regexp.MustCompile(`^[a-zA-Z0-9_]{0,127}$`)
+
 // ValidateHostServices validates a host service. Applies to the new API only.
 func ValidateHostServices(hs *HostService) error {
 
 	// Constraint on regex is used because the enforcer is using the name as nativeContextID.
 	if !regHostServiceName.MatchString(hs.Name) {
-		return makeValidationError("name", "Host service name must be less than 12 characters and contains only alphanumeric or _")
+		return makeValidationError("name", "Host service name must be less than 128 characters and contains only alphanumeric or _")
 	}
 
 	if !hs.HostModeEnabled && len(hs.Services) == 0 {

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -1004,6 +1004,24 @@ func TestValidateHostService(t *testing.T) {
 			false,
 		},
 		{
+			"valid service name < 128",
+			&HostService{
+				Name:            "asdasdsakljfslahfjashjkdlaksfjaksjfvfsadlkjkljsad",
+				HostModeEnabled: false,
+				Services:        []string{"tcp/80"},
+			},
+			false,
+		},
+		{
+			"valid service name > 128",
+			&HostService{
+				Name:            "asdasdsakljfslahfjashjkdlaksfsdhkjfhsdjkhfsiudfhsdjkfnsdkjfn1342141397asldjasklfjakslfj879797kjasdhjaksjfvfsadlkjkljsaddasfhsajlhdkajshfjksahfjksahdjksahdkjashdkasdhkjsa",
+				HostModeEnabled: false,
+				Services:        []string{"tcp/80"},
+			},
+			true,
+		},
+		{
 			"invalid name",
 			&HostService{
 				Name:            "jboss@!#$!$!",


### PR DESCRIPTION
--> Go easy on the regex and allow upto 128 chars.
--> [project](https://github.com/orgs/aporeto-inc/projects/556)