### PR TITLE
Protocol not required

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2611,7 +2611,7 @@ The event that triggered the report.
 
 Namespace of the processing unit reporting the packet.
 
-##### `protocol` `integer` [`required`,`max_value=255.000000`]
+##### `protocol` `integer` [`max_value=255.000000`]
 
 Protocol number.
 

--- a/packetreport.go
+++ b/packetreport.go
@@ -417,10 +417,6 @@ func (o *PacketReport) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateRequiredInt("protocol", o.Protocol); err != nil {
-		requiredErrors = requiredErrors.Append(err)
-	}
-
 	if err := elemental.ValidateMaximumInt("protocol", o.Protocol, int(255), false); err != nil {
 		errors = errors.Append(err)
 	}
@@ -637,7 +633,6 @@ Otherwise empty.`,
 		Exposed:        true,
 		MaxValue:       255,
 		Name:           "protocol",
-		Required:       true,
 		Type:           "integer",
 	},
 	"PuID": elemental.AttributeSpecification{
@@ -820,7 +815,6 @@ Otherwise empty.`,
 		Exposed:        true,
 		MaxValue:       255,
 		Name:           "protocol",
-		Required:       true,
 		Type:           "integer",
 	},
 	"puid": elemental.AttributeSpecification{

--- a/specs/packetreport.spec
+++ b/specs/packetreport.spec
@@ -100,7 +100,6 @@ attributes:
     description: Protocol number.
     type: integer
     exposed: true
-    required: true
     example_value: 6
     max_value: 255
 


### PR DESCRIPTION
Makes the protocol non-mandatory for packet reports in 3.11