### PR TITLE
fix: apoctl stats info|query for packets

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -10432,7 +10432,7 @@ Retrieves information about the content of the stats measurement.
 
 Contains the list of fields. You cannot group by these fields.
 
-##### `measurement` `emum(Flows | Audit | Enforcers | Files | EventLogs | Counters | Accesses)`
+##### `measurement` `emum(Flows | Audit | Enforcers | Files | EventLogs | Counters | Accesses | Packets)`
 
 Name of the measurement.
 

--- a/specs/statsinfo.spec
+++ b/specs/statsinfo.spec
@@ -32,6 +32,7 @@ attributes:
     - EventLogs
     - Counters
     - Accesses
+    - Packets
     default_value: Flows
 
   - name: tags

--- a/statsinfo.go
+++ b/statsinfo.go
@@ -31,6 +31,9 @@ const (
 
 	// StatsInfoMeasurementFlows represents the value Flows.
 	StatsInfoMeasurementFlows StatsInfoMeasurementValue = "Flows"
+
+	// StatsInfoMeasurementPackets represents the value Packets.
+	StatsInfoMeasurementPackets StatsInfoMeasurementValue = "Packets"
 )
 
 // StatsInfoIdentity represents the Identity of the object.
@@ -250,7 +253,7 @@ func (o *StatsInfo) Validate() error {
 	errors := elemental.Errors{}
 	requiredErrors := elemental.Errors{}
 
-	if err := elemental.ValidateStringInList("measurement", string(o.Measurement), []string{"Flows", "Audit", "Enforcers", "Files", "EventLogs", "Counters", "Accesses"}, false); err != nil {
+	if err := elemental.ValidateStringInList("measurement", string(o.Measurement), []string{"Flows", "Audit", "Enforcers", "Files", "EventLogs", "Counters", "Accesses", "Packets"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -313,7 +316,7 @@ var StatsInfoAttributesMap = map[string]elemental.AttributeSpecification{
 		Type:           "external",
 	},
 	"Measurement": elemental.AttributeSpecification{
-		AllowedChoices: []string{"Flows", "Audit", "Enforcers", "Files", "EventLogs", "Counters", "Accesses"},
+		AllowedChoices: []string{"Flows", "Audit", "Enforcers", "Files", "EventLogs", "Counters", "Accesses", "Packets"},
 		ConvertedName:  "Measurement",
 		DefaultValue:   StatsInfoMeasurementFlows,
 		Description:    `Name of the measurement.`,
@@ -348,7 +351,7 @@ var StatsInfoLowerCaseAttributesMap = map[string]elemental.AttributeSpecificatio
 		Type:           "external",
 	},
 	"measurement": elemental.AttributeSpecification{
-		AllowedChoices: []string{"Flows", "Audit", "Enforcers", "Files", "EventLogs", "Counters", "Accesses"},
+		AllowedChoices: []string{"Flows", "Audit", "Enforcers", "Files", "EventLogs", "Counters", "Accesses", "Packets"},
 		ConvertedName:  "Measurement",
 		DefaultValue:   StatsInfoMeasurementFlows,
 		Description:    `Name of the measurement.`,


### PR DESCRIPTION
Adding `packets` to the apoctl command. 