### PR TITLE
Adding disableDatapathExpression attribute to the enforcer profile

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -6569,6 +6569,15 @@ Creation date of the object.
 
 Description of the object.
 
+##### `disableDatapathExpression` `[][]string`
+
+A tag expression that identifies processing units that will disable datapath
+protection. This can be used in cases where Aporeto only acts as an authorizer.
+This will essentially not install any network protection for processing units,
+and will only offer authorization through an HTTP and an envoyproxy-compatible
+gRPC API. The user is responsible for using these APIs to protect the selected
+processing units themselves.
+
 ##### `excludedInterfaces` `[]string`
 
 Ignore traffic with a source or destination matching the specified

--- a/specs/enforcerprofile.spec
+++ b/specs/enforcerprofile.spec
@@ -41,6 +41,21 @@ model:
 # Attributes
 attributes:
   v1:
+  - name: disableDatapathExpression
+    description: |-
+      A tag expression that identifies processing units that will disable datapath
+      protection. This can be used in cases where Aporeto only acts as an authorizer.
+      This will essentially not install any network protection for processing units,
+      and will only offer authorization through an HTTP and an envoyproxy-compatible
+      gRPC API. The user is responsible for using these APIs to protect the selected
+      processing units themselves.
+    type: external
+    exposed: true
+    subtype: '[][]string'
+    stored: true
+    validations:
+    - $tagsExpression
+
   - name: excludedInterfaces
     description: |-
       Ignore traffic with a source or destination matching the specified


### PR DESCRIPTION
As discussed with @dstiliadis this morning: this change will allow us to select the type of enforcer we want to use for a PU through policies.

For various reasons I'd actually still prefer a new backend policy type. It is going to be hell to automatically update this for recognizing Istio PUs.