### PR TITLE
Fix fields in packet reports

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2710,6 +2710,14 @@ Create a packet trace report.
 
 #### Attributes
 
+##### `TCPFlags` `integer`
+
+Flags are the TCP flags of the packet.
+
+##### `claims` `[]string`
+
+Claims is the list of claims detected for the packet.
+
 ##### `destinationIP` `string`
 
 The destination IP address of the packet.
@@ -2739,7 +2747,7 @@ Namespace of the enforcer sending the report.
 
 The event that triggered the report.
 
-##### `namespace` `string` [`required`]
+##### `namespace` `string`
 
 Namespace of the processing unit reporting the packet.
 
@@ -2747,7 +2755,7 @@ Namespace of the processing unit reporting the packet.
 
 Protocol number.
 
-##### `puID` `string` [`required`]
+##### `puID` `string`
 
 The ID of the processing unit reporting the packet.
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2759,7 +2759,7 @@ Namespace of the processing unit reporting the packet.
 
 ##### `packetID` `integer`
 
-PacketID is the ID of the IP header.
+The ID of the IP header of the reported packet.
 
 ##### `protocol` `integer` [`max_value=255.000000`]
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2692,7 +2692,9 @@ Post a new packet tracing report.
   "enforcerID": "xxxx-xxx-xxxx",
   "enforcerNamespace": "/my/namespace",
   "event": "Rcv",
+  "mark": 123123,
   "namespace": "/my/namespace",
+  "packetID": 12333,
   "protocol": 6,
   "puID": "xxx-xxx-xxx",
   "rawPacket": "abcd",
@@ -2747,9 +2749,17 @@ Namespace of the enforcer sending the report.
 
 The event that triggered the report.
 
-##### `namespace` `string`
+##### `mark` `integer`
+
+Mark is the mark value of the packet.
+
+##### `namespace` `string` [`required`]
 
 Namespace of the processing unit reporting the packet.
+
+##### `packetID` `integer`
+
+PacketID is the ID from the IP header of the packet.
 
 ##### `protocol` `integer` [`max_value=255.000000`]
 
@@ -2781,7 +2791,7 @@ The source port of the packet.
 
 The time-date stamp of the report.
 
-##### `triremePacket` `boolean` [`required`]
+##### `triremePacket` `boolean`
 
 Set to `true` if the packet arrived with the Trireme options (default).
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2759,7 +2759,7 @@ Namespace of the processing unit reporting the packet.
 
 ##### `packetID` `integer`
 
-PacketID is the ID from the IP header of the packet.
+PacketID is the ID of the IP header.
 
 ##### `protocol` `integer` [`max_value=255.000000`]
 

--- a/packetreport.go
+++ b/packetreport.go
@@ -105,11 +105,11 @@ type PacketReport struct {
 	DestinationIP string `json:"destinationIP" msgpack:"destinationIP" bson:"destinationip" mapstructure:"destinationIP,omitempty"`
 
 	// The destination port of a TCP or UDP packet.
-	DestinationPort int `json:"destinationPort" msgpack:"destinationPort" bson:"-" mapstructure:"destinationPort,omitempty"`
+	DestinationPort int `json:"destinationPort" msgpack:"destinationPort" bson:"destinationport" mapstructure:"destinationPort,omitempty"`
 
 	// If `event` is set to `Dropped`, contains the reason that the packet was dropped.
 	// Otherwise empty.
-	DropReason string `json:"dropReason" msgpack:"dropReason" bson:"-" mapstructure:"dropReason,omitempty"`
+	DropReason string `json:"dropReason" msgpack:"dropReason" bson:"dropreason" mapstructure:"dropReason,omitempty"`
 
 	// Set to `true` if the packet was encrypted.
 	Encrypt bool `json:"encrypt" msgpack:"encrypt" bson:"encrypt" mapstructure:"encrypt,omitempty"`
@@ -124,34 +124,34 @@ type PacketReport struct {
 	Event PacketReportEventValue `json:"event" msgpack:"event" bson:"-" mapstructure:"event,omitempty"`
 
 	// Length is the length of the packet.
-	Length int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	Length int `json:"-" msgpack:"-" bson:"length" mapstructure:"-,omitempty"`
 
 	// Mark is the mark value of the packet.
-	Mark int `json:"mark" msgpack:"mark" bson:"-" mapstructure:"mark,omitempty"`
+	Mark int `json:"mark" msgpack:"mark" bson:"mark" mapstructure:"mark,omitempty"`
 
 	// Namespace of the processing unit reporting the packet.
-	Namespace string `json:"namespace" msgpack:"namespace" bson:"-" mapstructure:"namespace,omitempty"`
+	Namespace string `json:"namespace" msgpack:"namespace" bson:"namespace" mapstructure:"namespace,omitempty"`
 
 	// PacketID is the ID from the IP header of the packet.
-	PacketID int `json:"packetID" msgpack:"packetID" bson:"-" mapstructure:"packetID,omitempty"`
+	PacketID int `json:"packetID" msgpack:"packetID" bson:"packetid" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.
-	Protocol int `json:"protocol" msgpack:"protocol" bson:"-" mapstructure:"protocol,omitempty"`
+	Protocol int `json:"protocol" msgpack:"protocol" bson:"protocol" mapstructure:"protocol,omitempty"`
 
 	// The ID of the processing unit reporting the packet.
-	PuID string `json:"puID" msgpack:"puID" bson:"-" mapstructure:"puID,omitempty"`
+	PuID string `json:"puID" msgpack:"puID" bson:"puid" mapstructure:"puID,omitempty"`
 
 	// The first 64 bytes of the packet.
 	RawPacket string `json:"rawPacket" msgpack:"rawPacket" bson:"rawpacket" mapstructure:"rawPacket,omitempty"`
 
 	// The source IP address of the packet.
-	SourceIP string `json:"sourceIP" msgpack:"sourceIP" bson:"-" mapstructure:"sourceIP,omitempty"`
+	SourceIP string `json:"sourceIP" msgpack:"sourceIP" bson:"sourceip" mapstructure:"sourceIP,omitempty"`
 
 	// The source port of the packet.
-	SourcePort int `json:"sourcePort" msgpack:"sourcePort" bson:"-" mapstructure:"sourcePort,omitempty"`
+	SourcePort int `json:"sourcePort" msgpack:"sourcePort" bson:"sourceport" mapstructure:"sourcePort,omitempty"`
 
 	// The time-date stamp of the report.
-	Timestamp time.Time `json:"timestamp" msgpack:"timestamp" bson:"-" mapstructure:"timestamp,omitempty"`
+	Timestamp time.Time `json:"timestamp" msgpack:"timestamp" bson:"timestamp" mapstructure:"timestamp,omitempty"`
 
 	// Set to `true` if the packet arrived with the Trireme options (default).
 	TriremePacket bool `json:"triremePacket" msgpack:"triremePacket" bson:"triremepacket" mapstructure:"triremePacket,omitempty"`
@@ -200,10 +200,21 @@ func (o *PacketReport) GetBSON() (interface{}, error) {
 	s.TCPFlags = o.TCPFlags
 	s.Claims = o.Claims
 	s.DestinationIP = o.DestinationIP
+	s.DestinationPort = o.DestinationPort
+	s.DropReason = o.DropReason
 	s.Encrypt = o.Encrypt
 	s.EnforcerID = o.EnforcerID
 	s.EnforcerNamespace = o.EnforcerNamespace
+	s.Length = o.Length
+	s.Mark = o.Mark
+	s.Namespace = o.Namespace
+	s.PacketID = o.PacketID
+	s.Protocol = o.Protocol
+	s.PuID = o.PuID
 	s.RawPacket = o.RawPacket
+	s.SourceIP = o.SourceIP
+	s.SourcePort = o.SourcePort
+	s.Timestamp = o.Timestamp
 	s.TriremePacket = o.TriremePacket
 
 	return s, nil
@@ -225,10 +236,21 @@ func (o *PacketReport) SetBSON(raw bson.Raw) error {
 	o.TCPFlags = s.TCPFlags
 	o.Claims = s.Claims
 	o.DestinationIP = s.DestinationIP
+	o.DestinationPort = s.DestinationPort
+	o.DropReason = s.DropReason
 	o.Encrypt = s.Encrypt
 	o.EnforcerID = s.EnforcerID
 	o.EnforcerNamespace = s.EnforcerNamespace
+	o.Length = s.Length
+	o.Mark = s.Mark
+	o.Namespace = s.Namespace
+	o.PacketID = s.PacketID
+	o.Protocol = s.Protocol
+	o.PuID = s.PuID
 	o.RawPacket = s.RawPacket
+	o.SourceIP = s.SourceIP
+	o.SourcePort = s.SourcePort
+	o.Timestamp = s.Timestamp
 	o.TriremePacket = s.TriremePacket
 
 	return nil
@@ -593,6 +615,7 @@ var PacketReportAttributesMap = map[string]elemental.AttributeSpecification{
 		Exposed:        true,
 		MaxValue:       65536,
 		Name:           "destinationPort",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"DropReason": elemental.AttributeSpecification{
@@ -602,6 +625,7 @@ var PacketReportAttributesMap = map[string]elemental.AttributeSpecification{
 Otherwise empty.`,
 		Exposed: true,
 		Name:    "dropReason",
+		Stored:  true,
 		Type:    "string",
 	},
 	"Encrypt": elemental.AttributeSpecification{
@@ -648,6 +672,7 @@ Otherwise empty.`,
 		Description:    `Length is the length of the packet.`,
 		MaxValue:       65536,
 		Name:           "length",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"Mark": elemental.AttributeSpecification{
@@ -656,6 +681,7 @@ Otherwise empty.`,
 		Description:    `Mark is the mark value of the packet.`,
 		Exposed:        true,
 		Name:           "mark",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"Namespace": elemental.AttributeSpecification{
@@ -666,6 +692,7 @@ Otherwise empty.`,
 		Filterable:     true,
 		Name:           "namespace",
 		Required:       true,
+		Stored:         true,
 		Type:           "string",
 	},
 	"PacketID": elemental.AttributeSpecification{
@@ -674,6 +701,7 @@ Otherwise empty.`,
 		Description:    `PacketID is the ID from the IP header of the packet.`,
 		Exposed:        true,
 		Name:           "packetID",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"Protocol": elemental.AttributeSpecification{
@@ -683,6 +711,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		MaxValue:       255,
 		Name:           "protocol",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"PuID": elemental.AttributeSpecification{
@@ -692,6 +721,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "puID",
+		Stored:         true,
 		Type:           "string",
 	},
 	"RawPacket": elemental.AttributeSpecification{
@@ -710,6 +740,7 @@ Otherwise empty.`,
 		Description:    `The source IP address of the packet.`,
 		Exposed:        true,
 		Name:           "sourceIP",
+		Stored:         true,
 		Type:           "string",
 	},
 	"SourcePort": elemental.AttributeSpecification{
@@ -719,6 +750,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		MaxValue:       65536,
 		Name:           "sourcePort",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"Timestamp": elemental.AttributeSpecification{
@@ -728,6 +760,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		Name:           "timestamp",
 		Required:       true,
+		Stored:         true,
 		Type:           "time",
 	},
 	"TriremePacket": elemental.AttributeSpecification{
@@ -779,6 +812,7 @@ var PacketReportLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Exposed:        true,
 		MaxValue:       65536,
 		Name:           "destinationPort",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"dropreason": elemental.AttributeSpecification{
@@ -788,6 +822,7 @@ var PacketReportLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 Otherwise empty.`,
 		Exposed: true,
 		Name:    "dropReason",
+		Stored:  true,
 		Type:    "string",
 	},
 	"encrypt": elemental.AttributeSpecification{
@@ -834,6 +869,7 @@ Otherwise empty.`,
 		Description:    `Length is the length of the packet.`,
 		MaxValue:       65536,
 		Name:           "length",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"mark": elemental.AttributeSpecification{
@@ -842,6 +878,7 @@ Otherwise empty.`,
 		Description:    `Mark is the mark value of the packet.`,
 		Exposed:        true,
 		Name:           "mark",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"namespace": elemental.AttributeSpecification{
@@ -852,6 +889,7 @@ Otherwise empty.`,
 		Filterable:     true,
 		Name:           "namespace",
 		Required:       true,
+		Stored:         true,
 		Type:           "string",
 	},
 	"packetid": elemental.AttributeSpecification{
@@ -860,6 +898,7 @@ Otherwise empty.`,
 		Description:    `PacketID is the ID from the IP header of the packet.`,
 		Exposed:        true,
 		Name:           "packetID",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"protocol": elemental.AttributeSpecification{
@@ -869,6 +908,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		MaxValue:       255,
 		Name:           "protocol",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"puid": elemental.AttributeSpecification{
@@ -878,6 +918,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "puID",
+		Stored:         true,
 		Type:           "string",
 	},
 	"rawpacket": elemental.AttributeSpecification{
@@ -896,6 +937,7 @@ Otherwise empty.`,
 		Description:    `The source IP address of the packet.`,
 		Exposed:        true,
 		Name:           "sourceIP",
+		Stored:         true,
 		Type:           "string",
 	},
 	"sourceport": elemental.AttributeSpecification{
@@ -905,6 +947,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		MaxValue:       65536,
 		Name:           "sourcePort",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"timestamp": elemental.AttributeSpecification{
@@ -914,6 +957,7 @@ Otherwise empty.`,
 		Exposed:        true,
 		Name:           "timestamp",
 		Required:       true,
+		Stored:         true,
 		Type:           "time",
 	},
 	"triremepacket": elemental.AttributeSpecification{
@@ -1001,11 +1045,11 @@ type SparsePacketReport struct {
 	DestinationIP *string `json:"destinationIP,omitempty" msgpack:"destinationIP,omitempty" bson:"destinationip,omitempty" mapstructure:"destinationIP,omitempty"`
 
 	// The destination port of a TCP or UDP packet.
-	DestinationPort *int `json:"destinationPort,omitempty" msgpack:"destinationPort,omitempty" bson:"-" mapstructure:"destinationPort,omitempty"`
+	DestinationPort *int `json:"destinationPort,omitempty" msgpack:"destinationPort,omitempty" bson:"destinationport,omitempty" mapstructure:"destinationPort,omitempty"`
 
 	// If `event` is set to `Dropped`, contains the reason that the packet was dropped.
 	// Otherwise empty.
-	DropReason *string `json:"dropReason,omitempty" msgpack:"dropReason,omitempty" bson:"-" mapstructure:"dropReason,omitempty"`
+	DropReason *string `json:"dropReason,omitempty" msgpack:"dropReason,omitempty" bson:"dropreason,omitempty" mapstructure:"dropReason,omitempty"`
 
 	// Set to `true` if the packet was encrypted.
 	Encrypt *bool `json:"encrypt,omitempty" msgpack:"encrypt,omitempty" bson:"encrypt,omitempty" mapstructure:"encrypt,omitempty"`
@@ -1020,34 +1064,34 @@ type SparsePacketReport struct {
 	Event *PacketReportEventValue `json:"event,omitempty" msgpack:"event,omitempty" bson:"-" mapstructure:"event,omitempty"`
 
 	// Length is the length of the packet.
-	Length *int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	Length *int `json:"-" msgpack:"-" bson:"length,omitempty" mapstructure:"-,omitempty"`
 
 	// Mark is the mark value of the packet.
-	Mark *int `json:"mark,omitempty" msgpack:"mark,omitempty" bson:"-" mapstructure:"mark,omitempty"`
+	Mark *int `json:"mark,omitempty" msgpack:"mark,omitempty" bson:"mark,omitempty" mapstructure:"mark,omitempty"`
 
 	// Namespace of the processing unit reporting the packet.
-	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"-" mapstructure:"namespace,omitempty"`
+	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"namespace,omitempty" mapstructure:"namespace,omitempty"`
 
 	// PacketID is the ID from the IP header of the packet.
-	PacketID *int `json:"packetID,omitempty" msgpack:"packetID,omitempty" bson:"-" mapstructure:"packetID,omitempty"`
+	PacketID *int `json:"packetID,omitempty" msgpack:"packetID,omitempty" bson:"packetid,omitempty" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.
-	Protocol *int `json:"protocol,omitempty" msgpack:"protocol,omitempty" bson:"-" mapstructure:"protocol,omitempty"`
+	Protocol *int `json:"protocol,omitempty" msgpack:"protocol,omitempty" bson:"protocol,omitempty" mapstructure:"protocol,omitempty"`
 
 	// The ID of the processing unit reporting the packet.
-	PuID *string `json:"puID,omitempty" msgpack:"puID,omitempty" bson:"-" mapstructure:"puID,omitempty"`
+	PuID *string `json:"puID,omitempty" msgpack:"puID,omitempty" bson:"puid,omitempty" mapstructure:"puID,omitempty"`
 
 	// The first 64 bytes of the packet.
 	RawPacket *string `json:"rawPacket,omitempty" msgpack:"rawPacket,omitempty" bson:"rawpacket,omitempty" mapstructure:"rawPacket,omitempty"`
 
 	// The source IP address of the packet.
-	SourceIP *string `json:"sourceIP,omitempty" msgpack:"sourceIP,omitempty" bson:"-" mapstructure:"sourceIP,omitempty"`
+	SourceIP *string `json:"sourceIP,omitempty" msgpack:"sourceIP,omitempty" bson:"sourceip,omitempty" mapstructure:"sourceIP,omitempty"`
 
 	// The source port of the packet.
-	SourcePort *int `json:"sourcePort,omitempty" msgpack:"sourcePort,omitempty" bson:"-" mapstructure:"sourcePort,omitempty"`
+	SourcePort *int `json:"sourcePort,omitempty" msgpack:"sourcePort,omitempty" bson:"sourceport,omitempty" mapstructure:"sourcePort,omitempty"`
 
 	// The time-date stamp of the report.
-	Timestamp *time.Time `json:"timestamp,omitempty" msgpack:"timestamp,omitempty" bson:"-" mapstructure:"timestamp,omitempty"`
+	Timestamp *time.Time `json:"timestamp,omitempty" msgpack:"timestamp,omitempty" bson:"timestamp,omitempty" mapstructure:"timestamp,omitempty"`
 
 	// Set to `true` if the packet arrived with the Trireme options (default).
 	TriremePacket *bool `json:"triremePacket,omitempty" msgpack:"triremePacket,omitempty" bson:"triremepacket,omitempty" mapstructure:"triremePacket,omitempty"`
@@ -1096,6 +1140,12 @@ func (o *SparsePacketReport) GetBSON() (interface{}, error) {
 	if o.DestinationIP != nil {
 		s.DestinationIP = o.DestinationIP
 	}
+	if o.DestinationPort != nil {
+		s.DestinationPort = o.DestinationPort
+	}
+	if o.DropReason != nil {
+		s.DropReason = o.DropReason
+	}
 	if o.Encrypt != nil {
 		s.Encrypt = o.Encrypt
 	}
@@ -1105,8 +1155,35 @@ func (o *SparsePacketReport) GetBSON() (interface{}, error) {
 	if o.EnforcerNamespace != nil {
 		s.EnforcerNamespace = o.EnforcerNamespace
 	}
+	if o.Length != nil {
+		s.Length = o.Length
+	}
+	if o.Mark != nil {
+		s.Mark = o.Mark
+	}
+	if o.Namespace != nil {
+		s.Namespace = o.Namespace
+	}
+	if o.PacketID != nil {
+		s.PacketID = o.PacketID
+	}
+	if o.Protocol != nil {
+		s.Protocol = o.Protocol
+	}
+	if o.PuID != nil {
+		s.PuID = o.PuID
+	}
 	if o.RawPacket != nil {
 		s.RawPacket = o.RawPacket
+	}
+	if o.SourceIP != nil {
+		s.SourceIP = o.SourceIP
+	}
+	if o.SourcePort != nil {
+		s.SourcePort = o.SourcePort
+	}
+	if o.Timestamp != nil {
+		s.Timestamp = o.Timestamp
 	}
 	if o.TriremePacket != nil {
 		s.TriremePacket = o.TriremePacket
@@ -1137,6 +1214,12 @@ func (o *SparsePacketReport) SetBSON(raw bson.Raw) error {
 	if s.DestinationIP != nil {
 		o.DestinationIP = s.DestinationIP
 	}
+	if s.DestinationPort != nil {
+		o.DestinationPort = s.DestinationPort
+	}
+	if s.DropReason != nil {
+		o.DropReason = s.DropReason
+	}
 	if s.Encrypt != nil {
 		o.Encrypt = s.Encrypt
 	}
@@ -1146,8 +1229,35 @@ func (o *SparsePacketReport) SetBSON(raw bson.Raw) error {
 	if s.EnforcerNamespace != nil {
 		o.EnforcerNamespace = s.EnforcerNamespace
 	}
+	if s.Length != nil {
+		o.Length = s.Length
+	}
+	if s.Mark != nil {
+		o.Mark = s.Mark
+	}
+	if s.Namespace != nil {
+		o.Namespace = s.Namespace
+	}
+	if s.PacketID != nil {
+		o.PacketID = s.PacketID
+	}
+	if s.Protocol != nil {
+		o.Protocol = s.Protocol
+	}
+	if s.PuID != nil {
+		o.PuID = s.PuID
+	}
 	if s.RawPacket != nil {
 		o.RawPacket = s.RawPacket
+	}
+	if s.SourceIP != nil {
+		o.SourceIP = s.SourceIP
+	}
+	if s.SourcePort != nil {
+		o.SourcePort = s.SourcePort
+	}
+	if s.Timestamp != nil {
+		o.Timestamp = s.Timestamp
 	}
 	if s.TriremePacket != nil {
 		o.TriremePacket = s.TriremePacket
@@ -1255,22 +1365,44 @@ func (o *SparsePacketReport) DeepCopyInto(out *SparsePacketReport) {
 }
 
 type mongoAttributesPacketReport struct {
-	TCPFlags          int      `bson:"tcpflags"`
-	Claims            []string `bson:"claims"`
-	DestinationIP     string   `bson:"destinationip"`
-	Encrypt           bool     `bson:"encrypt"`
-	EnforcerID        string   `bson:"enforcerid"`
-	EnforcerNamespace string   `bson:"enforcernamespace"`
-	RawPacket         string   `bson:"rawpacket"`
-	TriremePacket     bool     `bson:"triremepacket"`
+	TCPFlags          int       `bson:"tcpflags"`
+	Claims            []string  `bson:"claims"`
+	DestinationIP     string    `bson:"destinationip"`
+	DestinationPort   int       `bson:"destinationport"`
+	DropReason        string    `bson:"dropreason"`
+	Encrypt           bool      `bson:"encrypt"`
+	EnforcerID        string    `bson:"enforcerid"`
+	EnforcerNamespace string    `bson:"enforcernamespace"`
+	Length            int       `bson:"length"`
+	Mark              int       `bson:"mark"`
+	Namespace         string    `bson:"namespace"`
+	PacketID          int       `bson:"packetid"`
+	Protocol          int       `bson:"protocol"`
+	PuID              string    `bson:"puid"`
+	RawPacket         string    `bson:"rawpacket"`
+	SourceIP          string    `bson:"sourceip"`
+	SourcePort        int       `bson:"sourceport"`
+	Timestamp         time.Time `bson:"timestamp"`
+	TriremePacket     bool      `bson:"triremepacket"`
 }
 type mongoAttributesSparsePacketReport struct {
-	TCPFlags          *int      `bson:"tcpflags,omitempty"`
-	Claims            *[]string `bson:"claims,omitempty"`
-	DestinationIP     *string   `bson:"destinationip,omitempty"`
-	Encrypt           *bool     `bson:"encrypt,omitempty"`
-	EnforcerID        *string   `bson:"enforcerid,omitempty"`
-	EnforcerNamespace *string   `bson:"enforcernamespace,omitempty"`
-	RawPacket         *string   `bson:"rawpacket,omitempty"`
-	TriremePacket     *bool     `bson:"triremepacket,omitempty"`
+	TCPFlags          *int       `bson:"tcpflags,omitempty"`
+	Claims            *[]string  `bson:"claims,omitempty"`
+	DestinationIP     *string    `bson:"destinationip,omitempty"`
+	DestinationPort   *int       `bson:"destinationport,omitempty"`
+	DropReason        *string    `bson:"dropreason,omitempty"`
+	Encrypt           *bool      `bson:"encrypt,omitempty"`
+	EnforcerID        *string    `bson:"enforcerid,omitempty"`
+	EnforcerNamespace *string    `bson:"enforcernamespace,omitempty"`
+	Length            *int       `bson:"length,omitempty"`
+	Mark              *int       `bson:"mark,omitempty"`
+	Namespace         *string    `bson:"namespace,omitempty"`
+	PacketID          *int       `bson:"packetid,omitempty"`
+	Protocol          *int       `bson:"protocol,omitempty"`
+	PuID              *string    `bson:"puid,omitempty"`
+	RawPacket         *string    `bson:"rawpacket,omitempty"`
+	SourceIP          *string    `bson:"sourceip,omitempty"`
+	SourcePort        *int       `bson:"sourceport,omitempty"`
+	Timestamp         *time.Time `bson:"timestamp,omitempty"`
+	TriremePacket     *bool      `bson:"triremepacket,omitempty"`
 }

--- a/packetreport.go
+++ b/packetreport.go
@@ -132,7 +132,7 @@ type PacketReport struct {
 	// Namespace of the processing unit reporting the packet.
 	Namespace string `json:"namespace" msgpack:"namespace" bson:"namespace" mapstructure:"namespace,omitempty"`
 
-	// PacketID is the ID of the IP header.
+	// The ID of the IP header of the reported packet.
 	PacketID int `json:"packetID" msgpack:"packetID" bson:"packetid" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.
@@ -698,7 +698,7 @@ Otherwise empty.`,
 	"PacketID": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "PacketID",
-		Description:    `PacketID is the ID of the IP header.`,
+		Description:    `The ID of the IP header of the reported packet.`,
 		Exposed:        true,
 		Name:           "packetID",
 		Stored:         true,
@@ -895,7 +895,7 @@ Otherwise empty.`,
 	"packetid": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "PacketID",
-		Description:    `PacketID is the ID of the IP header.`,
+		Description:    `The ID of the IP header of the reported packet.`,
 		Exposed:        true,
 		Name:           "packetID",
 		Stored:         true,
@@ -1072,7 +1072,7 @@ type SparsePacketReport struct {
 	// Namespace of the processing unit reporting the packet.
 	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"namespace,omitempty" mapstructure:"namespace,omitempty"`
 
-	// PacketID is the ID of the IP header.
+	// The ID of the IP header of the reported packet.
 	PacketID *int `json:"packetID,omitempty" msgpack:"packetID,omitempty" bson:"packetid,omitempty" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.

--- a/packetreport.go
+++ b/packetreport.go
@@ -96,13 +96,13 @@ func (o PacketReportsList) Version() int {
 // PacketReport represents the model of a packetreport
 type PacketReport struct {
 	// Flags are the TCP flags of the packet.
-	TCPFlags int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	TCPFlags int `json:"TCPFlags" msgpack:"TCPFlags" bson:"tcpflags" mapstructure:"TCPFlags,omitempty"`
 
 	// Claims is the list of claims detected for the packet.
-	Claims []string `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	Claims []string `json:"claims" msgpack:"claims" bson:"claims" mapstructure:"claims,omitempty"`
 
 	// The destination IP address of the packet.
-	DestinationIP string `json:"destinationIP" msgpack:"destinationIP" bson:"-" mapstructure:"destinationIP,omitempty"`
+	DestinationIP string `json:"destinationIP" msgpack:"destinationIP" bson:"destinationip" mapstructure:"destinationIP,omitempty"`
 
 	// The destination port of a TCP or UDP packet.
 	DestinationPort int `json:"destinationPort" msgpack:"destinationPort" bson:"-" mapstructure:"destinationPort,omitempty"`
@@ -112,7 +112,7 @@ type PacketReport struct {
 	DropReason string `json:"dropReason" msgpack:"dropReason" bson:"-" mapstructure:"dropReason,omitempty"`
 
 	// Set to `true` if the packet was encrypted.
-	Encrypt bool `json:"encrypt" msgpack:"encrypt" bson:"-" mapstructure:"encrypt,omitempty"`
+	Encrypt bool `json:"encrypt" msgpack:"encrypt" bson:"encrypt" mapstructure:"encrypt,omitempty"`
 
 	// Identifier of the enforcer sending the report.
 	EnforcerID string `json:"enforcerID" msgpack:"enforcerID" bson:"enforcerid" mapstructure:"enforcerID,omitempty"`
@@ -197,6 +197,10 @@ func (o *PacketReport) GetBSON() (interface{}, error) {
 
 	s := &mongoAttributesPacketReport{}
 
+	s.TCPFlags = o.TCPFlags
+	s.Claims = o.Claims
+	s.DestinationIP = o.DestinationIP
+	s.Encrypt = o.Encrypt
 	s.EnforcerID = o.EnforcerID
 	s.EnforcerNamespace = o.EnforcerNamespace
 	s.RawPacket = o.RawPacket
@@ -218,6 +222,10 @@ func (o *PacketReport) SetBSON(raw bson.Raw) error {
 		return err
 	}
 
+	o.TCPFlags = s.TCPFlags
+	o.Claims = s.Claims
+	o.DestinationIP = s.DestinationIP
+	o.Encrypt = s.Encrypt
 	o.EnforcerID = s.EnforcerID
 	o.EnforcerNamespace = s.EnforcerNamespace
 	o.RawPacket = s.RawPacket
@@ -453,16 +461,8 @@ func (o *PacketReport) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateRequiredString("namespace", o.Namespace); err != nil {
-		requiredErrors = requiredErrors.Append(err)
-	}
-
 	if err := elemental.ValidateMaximumInt("protocol", o.Protocol, int(255), false); err != nil {
 		errors = errors.Append(err)
-	}
-
-	if err := elemental.ValidateRequiredString("puID", o.PuID); err != nil {
-		requiredErrors = requiredErrors.Append(err)
 	}
 
 	if err := elemental.ValidateMaximumInt("sourcePort", o.SourcePort, int(65536), false); err != nil {
@@ -558,14 +558,18 @@ var PacketReportAttributesMap = map[string]elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "TCPFlags",
 		Description:    `Flags are the TCP flags of the packet.`,
+		Exposed:        true,
 		Name:           "TCPFlags",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"Claims": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "Claims",
 		Description:    `Claims is the list of claims detected for the packet.`,
+		Exposed:        true,
 		Name:           "claims",
+		Stored:         true,
 		SubType:        "string",
 		Type:           "list",
 	},
@@ -575,6 +579,7 @@ var PacketReportAttributesMap = map[string]elemental.AttributeSpecification{
 		Description:    `The destination IP address of the packet.`,
 		Exposed:        true,
 		Name:           "destinationIP",
+		Stored:         true,
 		Type:           "string",
 	},
 	"DestinationPort": elemental.AttributeSpecification{
@@ -601,6 +606,7 @@ Otherwise empty.`,
 		Description:    `Set to ` + "`" + `true` + "`" + ` if the packet was encrypted.`,
 		Exposed:        true,
 		Name:           "encrypt",
+		Stored:         true,
 		Type:           "boolean",
 	},
 	"EnforcerID": elemental.AttributeSpecification{
@@ -655,7 +661,6 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "namespace",
-		Required:       true,
 		Type:           "string",
 	},
 	"PacketID": elemental.AttributeSpecification{
@@ -682,7 +687,6 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "puID",
-		Required:       true,
 		Type:           "string",
 	},
 	"RawPacket": elemental.AttributeSpecification{
@@ -740,14 +744,18 @@ var PacketReportLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		AllowedChoices: []string{},
 		ConvertedName:  "TCPFlags",
 		Description:    `Flags are the TCP flags of the packet.`,
+		Exposed:        true,
 		Name:           "TCPFlags",
+		Stored:         true,
 		Type:           "integer",
 	},
 	"claims": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "Claims",
 		Description:    `Claims is the list of claims detected for the packet.`,
+		Exposed:        true,
 		Name:           "claims",
+		Stored:         true,
 		SubType:        "string",
 		Type:           "list",
 	},
@@ -757,6 +765,7 @@ var PacketReportLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Description:    `The destination IP address of the packet.`,
 		Exposed:        true,
 		Name:           "destinationIP",
+		Stored:         true,
 		Type:           "string",
 	},
 	"destinationport": elemental.AttributeSpecification{
@@ -783,6 +792,7 @@ Otherwise empty.`,
 		Description:    `Set to ` + "`" + `true` + "`" + ` if the packet was encrypted.`,
 		Exposed:        true,
 		Name:           "encrypt",
+		Stored:         true,
 		Type:           "boolean",
 	},
 	"enforcerid": elemental.AttributeSpecification{
@@ -837,7 +847,6 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "namespace",
-		Required:       true,
 		Type:           "string",
 	},
 	"packetid": elemental.AttributeSpecification{
@@ -864,7 +873,6 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "puID",
-		Required:       true,
 		Type:           "string",
 	},
 	"rawpacket": elemental.AttributeSpecification{
@@ -980,13 +988,13 @@ func (o SparsePacketReportsList) Version() int {
 // SparsePacketReport represents the sparse version of a packetreport.
 type SparsePacketReport struct {
 	// Flags are the TCP flags of the packet.
-	TCPFlags *int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	TCPFlags *int `json:"TCPFlags,omitempty" msgpack:"TCPFlags,omitempty" bson:"tcpflags,omitempty" mapstructure:"TCPFlags,omitempty"`
 
 	// Claims is the list of claims detected for the packet.
-	Claims *[]string `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	Claims *[]string `json:"claims,omitempty" msgpack:"claims,omitempty" bson:"claims,omitempty" mapstructure:"claims,omitempty"`
 
 	// The destination IP address of the packet.
-	DestinationIP *string `json:"destinationIP,omitempty" msgpack:"destinationIP,omitempty" bson:"-" mapstructure:"destinationIP,omitempty"`
+	DestinationIP *string `json:"destinationIP,omitempty" msgpack:"destinationIP,omitempty" bson:"destinationip,omitempty" mapstructure:"destinationIP,omitempty"`
 
 	// The destination port of a TCP or UDP packet.
 	DestinationPort *int `json:"destinationPort,omitempty" msgpack:"destinationPort,omitempty" bson:"-" mapstructure:"destinationPort,omitempty"`
@@ -996,7 +1004,7 @@ type SparsePacketReport struct {
 	DropReason *string `json:"dropReason,omitempty" msgpack:"dropReason,omitempty" bson:"-" mapstructure:"dropReason,omitempty"`
 
 	// Set to `true` if the packet was encrypted.
-	Encrypt *bool `json:"encrypt,omitempty" msgpack:"encrypt,omitempty" bson:"-" mapstructure:"encrypt,omitempty"`
+	Encrypt *bool `json:"encrypt,omitempty" msgpack:"encrypt,omitempty" bson:"encrypt,omitempty" mapstructure:"encrypt,omitempty"`
 
 	// Identifier of the enforcer sending the report.
 	EnforcerID *string `json:"enforcerID,omitempty" msgpack:"enforcerID,omitempty" bson:"enforcerid,omitempty" mapstructure:"enforcerID,omitempty"`
@@ -1075,6 +1083,18 @@ func (o *SparsePacketReport) GetBSON() (interface{}, error) {
 
 	s := &mongoAttributesSparsePacketReport{}
 
+	if o.TCPFlags != nil {
+		s.TCPFlags = o.TCPFlags
+	}
+	if o.Claims != nil {
+		s.Claims = o.Claims
+	}
+	if o.DestinationIP != nil {
+		s.DestinationIP = o.DestinationIP
+	}
+	if o.Encrypt != nil {
+		s.Encrypt = o.Encrypt
+	}
 	if o.EnforcerID != nil {
 		s.EnforcerID = o.EnforcerID
 	}
@@ -1104,6 +1124,18 @@ func (o *SparsePacketReport) SetBSON(raw bson.Raw) error {
 		return err
 	}
 
+	if s.TCPFlags != nil {
+		o.TCPFlags = s.TCPFlags
+	}
+	if s.Claims != nil {
+		o.Claims = s.Claims
+	}
+	if s.DestinationIP != nil {
+		o.DestinationIP = s.DestinationIP
+	}
+	if s.Encrypt != nil {
+		o.Encrypt = s.Encrypt
+	}
 	if s.EnforcerID != nil {
 		o.EnforcerID = s.EnforcerID
 	}
@@ -1219,14 +1251,22 @@ func (o *SparsePacketReport) DeepCopyInto(out *SparsePacketReport) {
 }
 
 type mongoAttributesPacketReport struct {
-	EnforcerID        string `bson:"enforcerid"`
-	EnforcerNamespace string `bson:"enforcernamespace"`
-	RawPacket         string `bson:"rawpacket"`
-	TriremePacket     bool   `bson:"triremepacket"`
+	TCPFlags          int      `bson:"tcpflags"`
+	Claims            []string `bson:"claims"`
+	DestinationIP     string   `bson:"destinationip"`
+	Encrypt           bool     `bson:"encrypt"`
+	EnforcerID        string   `bson:"enforcerid"`
+	EnforcerNamespace string   `bson:"enforcernamespace"`
+	RawPacket         string   `bson:"rawpacket"`
+	TriremePacket     bool     `bson:"triremepacket"`
 }
 type mongoAttributesSparsePacketReport struct {
-	EnforcerID        *string `bson:"enforcerid,omitempty"`
-	EnforcerNamespace *string `bson:"enforcernamespace,omitempty"`
-	RawPacket         *string `bson:"rawpacket,omitempty"`
-	TriremePacket     *bool   `bson:"triremepacket,omitempty"`
+	TCPFlags          *int      `bson:"tcpflags,omitempty"`
+	Claims            *[]string `bson:"claims,omitempty"`
+	DestinationIP     *string   `bson:"destinationip,omitempty"`
+	Encrypt           *bool     `bson:"encrypt,omitempty"`
+	EnforcerID        *string   `bson:"enforcerid,omitempty"`
+	EnforcerNamespace *string   `bson:"enforcernamespace,omitempty"`
+	RawPacket         *string   `bson:"rawpacket,omitempty"`
+	TriremePacket     *bool     `bson:"triremepacket,omitempty"`
 }

--- a/packetreport.go
+++ b/packetreport.go
@@ -127,13 +127,13 @@ type PacketReport struct {
 	Length int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
 
 	// Mark is the mark value of the packet.
-	Mark int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	Mark int `json:"mark" msgpack:"mark" bson:"-" mapstructure:"mark,omitempty"`
 
 	// Namespace of the processing unit reporting the packet.
 	Namespace string `json:"namespace" msgpack:"namespace" bson:"-" mapstructure:"namespace,omitempty"`
 
 	// PacketID is the ID from the IP header of the packet.
-	PacketID int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	PacketID int `json:"packetID" msgpack:"packetID" bson:"-" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.
 	Protocol int `json:"protocol" msgpack:"protocol" bson:"-" mapstructure:"protocol,omitempty"`
@@ -461,6 +461,10 @@ func (o *PacketReport) Validate() error {
 		errors = errors.Append(err)
 	}
 
+	if err := elemental.ValidateRequiredString("namespace", o.Namespace); err != nil {
+		requiredErrors = requiredErrors.Append(err)
+	}
+
 	if err := elemental.ValidateMaximumInt("protocol", o.Protocol, int(255), false); err != nil {
 		errors = errors.Append(err)
 	}
@@ -650,8 +654,8 @@ Otherwise empty.`,
 		AllowedChoices: []string{},
 		ConvertedName:  "Mark",
 		Description:    `Mark is the mark value of the packet.`,
+		Exposed:        true,
 		Name:           "mark",
-		Required:       true,
 		Type:           "integer",
 	},
 	"Namespace": elemental.AttributeSpecification{
@@ -661,14 +665,15 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "namespace",
+		Required:       true,
 		Type:           "string",
 	},
 	"PacketID": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "PacketID",
 		Description:    `PacketID is the ID from the IP header of the packet.`,
+		Exposed:        true,
 		Name:           "packetID",
-		Required:       true,
 		Type:           "integer",
 	},
 	"Protocol": elemental.AttributeSpecification{
@@ -732,7 +737,6 @@ Otherwise empty.`,
 		Description:    `Set to ` + "`" + `true` + "`" + ` if the packet arrived with the Trireme options (default).`,
 		Exposed:        true,
 		Name:           "triremePacket",
-		Required:       true,
 		Stored:         true,
 		Type:           "boolean",
 	},
@@ -836,8 +840,8 @@ Otherwise empty.`,
 		AllowedChoices: []string{},
 		ConvertedName:  "Mark",
 		Description:    `Mark is the mark value of the packet.`,
+		Exposed:        true,
 		Name:           "mark",
-		Required:       true,
 		Type:           "integer",
 	},
 	"namespace": elemental.AttributeSpecification{
@@ -847,14 +851,15 @@ Otherwise empty.`,
 		Exposed:        true,
 		Filterable:     true,
 		Name:           "namespace",
+		Required:       true,
 		Type:           "string",
 	},
 	"packetid": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "PacketID",
 		Description:    `PacketID is the ID from the IP header of the packet.`,
+		Exposed:        true,
 		Name:           "packetID",
-		Required:       true,
 		Type:           "integer",
 	},
 	"protocol": elemental.AttributeSpecification{
@@ -918,7 +923,6 @@ Otherwise empty.`,
 		Description:    `Set to ` + "`" + `true` + "`" + ` if the packet arrived with the Trireme options (default).`,
 		Exposed:        true,
 		Name:           "triremePacket",
-		Required:       true,
 		Stored:         true,
 		Type:           "boolean",
 	},
@@ -1019,13 +1023,13 @@ type SparsePacketReport struct {
 	Length *int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
 
 	// Mark is the mark value of the packet.
-	Mark *int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	Mark *int `json:"mark,omitempty" msgpack:"mark,omitempty" bson:"-" mapstructure:"mark,omitempty"`
 
 	// Namespace of the processing unit reporting the packet.
 	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"-" mapstructure:"namespace,omitempty"`
 
 	// PacketID is the ID from the IP header of the packet.
-	PacketID *int `json:"-" msgpack:"-" bson:"-" mapstructure:"-,omitempty"`
+	PacketID *int `json:"packetID,omitempty" msgpack:"packetID,omitempty" bson:"-" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.
 	Protocol *int `json:"protocol,omitempty" msgpack:"protocol,omitempty" bson:"-" mapstructure:"protocol,omitempty"`

--- a/packetreport.go
+++ b/packetreport.go
@@ -132,7 +132,7 @@ type PacketReport struct {
 	// Namespace of the processing unit reporting the packet.
 	Namespace string `json:"namespace" msgpack:"namespace" bson:"namespace" mapstructure:"namespace,omitempty"`
 
-	// PacketID is the ID from the IP header of the packet.
+	// PacketID is the ID of the IP header.
 	PacketID int `json:"packetID" msgpack:"packetID" bson:"packetid" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.
@@ -698,7 +698,7 @@ Otherwise empty.`,
 	"PacketID": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "PacketID",
-		Description:    `PacketID is the ID from the IP header of the packet.`,
+		Description:    `PacketID is the ID of the IP header.`,
 		Exposed:        true,
 		Name:           "packetID",
 		Stored:         true,
@@ -895,7 +895,7 @@ Otherwise empty.`,
 	"packetid": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "PacketID",
-		Description:    `PacketID is the ID from the IP header of the packet.`,
+		Description:    `PacketID is the ID of the IP header.`,
 		Exposed:        true,
 		Name:           "packetID",
 		Stored:         true,
@@ -1072,7 +1072,7 @@ type SparsePacketReport struct {
 	// Namespace of the processing unit reporting the packet.
 	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"namespace,omitempty" mapstructure:"namespace,omitempty"`
 
-	// PacketID is the ID from the IP header of the packet.
+	// PacketID is the ID of the IP header.
 	PacketID *int `json:"packetID,omitempty" msgpack:"packetID,omitempty" bson:"packetid,omitempty" mapstructure:"packetID,omitempty"`
 
 	// Protocol number.

--- a/specs/packetreport.spec
+++ b/specs/packetreport.spec
@@ -13,16 +13,21 @@ attributes:
   - name: TCPFlags
     description: Flags are the TCP flags of the packet.
     type: integer
+    exposed: true
+    stored: true
 
   - name: claims
     description: Claims is the list of claims detected for the packet.
     type: list
+    exposed: true
     subtype: string
+    stored: true
 
   - name: destinationIP
     description: The destination IP address of the packet.
     type: string
     exposed: true
+    stored: true
 
   - name: destinationPort
     description: The destination port of a TCP or UDP packet.
@@ -42,6 +47,7 @@ attributes:
     description: Set to `true` if the packet was encrypted.
     type: boolean
     exposed: true
+    stored: true
 
   - name: enforcerID
     description: Identifier of the enforcer sending the report.
@@ -86,7 +92,6 @@ attributes:
     description: Namespace of the processing unit reporting the packet.
     type: string
     exposed: true
-    required: true
     example_value: /my/namespace
     filterable: true
 
@@ -107,7 +112,6 @@ attributes:
     description: The ID of the processing unit reporting the packet.
     type: string
     exposed: true
-    required: true
     example_value: xxx-xxx-xxx
     filterable: true
 

--- a/specs/packetreport.spec
+++ b/specs/packetreport.spec
@@ -102,7 +102,7 @@ attributes:
     filterable: true
 
   - name: packetID
-    description: PacketID is the ID from the IP header of the packet.
+    description: PacketID is the ID of the IP header.
     type: integer
     exposed: true
     stored: true

--- a/specs/packetreport.spec
+++ b/specs/packetreport.spec
@@ -102,7 +102,7 @@ attributes:
     filterable: true
 
   - name: packetID
-    description: PacketID is the ID of the IP header.
+    description: The ID of the IP header of the reported packet.
     type: integer
     exposed: true
     stored: true

--- a/specs/packetreport.spec
+++ b/specs/packetreport.spec
@@ -85,20 +85,21 @@ attributes:
   - name: mark
     description: Mark is the mark value of the packet.
     type: integer
-    required: true
+    exposed: true
     example_value: 123123
 
   - name: namespace
     description: Namespace of the processing unit reporting the packet.
     type: string
     exposed: true
+    required: true
     example_value: /my/namespace
     filterable: true
 
   - name: packetID
     description: PacketID is the ID from the IP header of the packet.
     type: integer
-    required: true
+    exposed: true
     example_value: 12333
 
   - name: protocol
@@ -146,5 +147,4 @@ attributes:
     type: boolean
     exposed: true
     stored: true
-    required: true
     default_value: true

--- a/specs/packetreport.spec
+++ b/specs/packetreport.spec
@@ -33,6 +33,7 @@ attributes:
     description: The destination port of a TCP or UDP packet.
     type: integer
     exposed: true
+    stored: true
     example_value: 11000
     max_value: 65536
 
@@ -42,6 +43,7 @@ attributes:
       Otherwise empty.
     type: string
     exposed: true
+    stored: true
 
   - name: encrypt
     description: Set to `true` if the packet was encrypted.
@@ -79,6 +81,7 @@ attributes:
   - name: length
     description: Length is the length of the packet.
     type: integer
+    stored: true
     example_value: 94
     max_value: 65536
 
@@ -86,12 +89,14 @@ attributes:
     description: Mark is the mark value of the packet.
     type: integer
     exposed: true
+    stored: true
     example_value: 123123
 
   - name: namespace
     description: Namespace of the processing unit reporting the packet.
     type: string
     exposed: true
+    stored: true
     required: true
     example_value: /my/namespace
     filterable: true
@@ -100,12 +105,14 @@ attributes:
     description: PacketID is the ID from the IP header of the packet.
     type: integer
     exposed: true
+    stored: true
     example_value: 12333
 
   - name: protocol
     description: Protocol number.
     type: integer
     exposed: true
+    stored: true
     example_value: 6
     max_value: 255
 
@@ -113,6 +120,7 @@ attributes:
     description: The ID of the processing unit reporting the packet.
     type: string
     exposed: true
+    stored: true
     example_value: xxx-xxx-xxx
     filterable: true
 
@@ -127,11 +135,13 @@ attributes:
     description: The source IP address of the packet.
     type: string
     exposed: true
+    stored: true
 
   - name: sourcePort
     description: The source port of the packet.
     type: integer
     exposed: true
+    stored: true
     example_value: 80
     max_value: 65536
 
@@ -139,6 +149,7 @@ attributes:
     description: The time-date stamp of the report.
     type: time
     exposed: true
+    stored: true
     required: true
     example_value: "2018-06-14T23:10:46.420397985Z"
 


### PR DESCRIPTION
The namespace field and pu ID field can be empty. If this is the case, pick the namespace from the caller.

Fields were marked as not exposed and lost in the process.