### PR TITLE
fix: add default_value to allow (3) for default syscall action

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -8965,6 +8965,7 @@ processing unit.
 
 ```json
 {
+  "defaultSyscallAction": 3,
   "name": "the name",
   "propagate": false,
   "protected": false
@@ -9032,6 +9033,12 @@ Creation date of the object.
 
 The default action applied to all system calls of this profile.
 Default is `Allow`.
+
+Default value:
+
+```json
+3
+```
 
 ##### `description` `string` [`max_length=1024`]
 

--- a/isolationprofile.go
+++ b/isolationprofile.go
@@ -158,15 +158,16 @@ type IsolationProfile struct {
 func NewIsolationProfile() *IsolationProfile {
 
 	return &IsolationProfile{
-		ModelVersion:        1,
-		Annotations:         map[string][]string{},
-		AssociatedTags:      []string{},
-		CapabilitiesActions: types.CapabilitiesTypeMap{},
-		MigrationsLog:       map[string]string{},
-		NormalizedTags:      []string{},
-		Metadata:            []string{},
-		SyscallRules:        types.SyscallEnforcementRulesMap{},
-		TargetArchitectures: types.ArchitecturesTypeList{},
+		ModelVersion:         1,
+		Annotations:          map[string][]string{},
+		DefaultSyscallAction: 3,
+		AssociatedTags:       []string{},
+		CapabilitiesActions:  types.CapabilitiesTypeMap{},
+		MigrationsLog:        map[string]string{},
+		NormalizedTags:       []string{},
+		Metadata:             []string{},
+		SyscallRules:         types.SyscallEnforcementRulesMap{},
+		TargetArchitectures:  types.ArchitecturesTypeList{},
 	}
 }
 
@@ -852,6 +853,7 @@ var IsolationProfileAttributesMap = map[string]elemental.AttributeSpecification{
 	"DefaultSyscallAction": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "DefaultSyscallAction",
+		DefaultValue:   3,
 		Description: `The default action applied to all system calls of this profile.
 Default is ` + "`" + `Allow` + "`" + `.`,
 		Exposed: true,
@@ -1126,6 +1128,7 @@ var IsolationProfileLowerCaseAttributesMap = map[string]elemental.AttributeSpeci
 	"defaultsyscallaction": elemental.AttributeSpecification{
 		AllowedChoices: []string{},
 		ConvertedName:  "DefaultSyscallAction",
+		DefaultValue:   3,
 		Description: `The default action applied to all system calls of this profile.
 Default is ` + "`" + `Allow` + "`" + `.`,
 		Exposed: true,

--- a/specs/isolationprofile.spec
+++ b/specs/isolationprofile.spec
@@ -50,6 +50,7 @@ attributes:
     exposed: true
     subtype: _syscall_action
     stored: true
+    default_value: 3
 
   - name: syscallRules
     description: |-


### PR DESCRIPTION
Easy fix but we would need to convert all the isolation profiles into a proper gaia spec (See https://github.com/aporeto-inc/aporeto/issues/2362)

For now, I added a default value to 3 which means Allow.

> Fixes https://github.com/aporeto-inc/aporeto/issues/2360 