### PR TITLE
fixed: add validation to ensure tokenScopePolicy's assignedScopes is not empty

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -851,3 +851,13 @@ func ValidateIdentity(attribute string, identity string) error {
 
 	return nil
 }
+
+// ValidateStringListNotEmpty validates the given string slice is not empty (or nil).
+func ValidateStringListNotEmpty(attribute string, slice []string) error {
+
+	if len(slice) == 0 {
+		return makeValidationError(attribute, "String list must not be empty")
+	}
+
+	return nil
+}

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -2228,3 +2228,47 @@ func TestValidateProcessingUnitPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateStringListNotEmpty(t *testing.T) {
+	type args struct {
+		attribute string
+		slice     []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"nil",
+			args{
+				"attr",
+				nil,
+			},
+			true,
+		},
+		{
+			"empty",
+			args{
+				"attr",
+				[]string{},
+			},
+			true,
+		},
+		{
+			"set",
+			args{
+				"attr",
+				[]string{"a=a"},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateStringListNotEmpty(tt.args.attribute, tt.args.slice); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateStringListNotEmpty() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/specs/_validation.mapping
+++ b/specs/_validation.mapping
@@ -94,6 +94,10 @@ $serviceports:
   elemental:
     name: ValidateServicePorts
 
+$stringlistnotempty:
+  elemental:
+    name: ValidateStringListNotEmpty
+
 $tag:
   elemental:
     name: ValidateTag

--- a/specs/tokenscopepolicy.spec
+++ b/specs/tokenscopepolicy.spec
@@ -65,6 +65,8 @@ attributes:
     subtype: string
     stored: true
     orderable: true
+    validations:
+    - $stringlistnotempty
 
   - name: expirationTime
     description: If set the policy will be automatically deleted after the given time.

--- a/tokenscopepolicy.go
+++ b/tokenscopepolicy.go
@@ -734,6 +734,10 @@ func (o *TokenScopePolicy) Validate() error {
 		errors = errors.Append(err)
 	}
 
+	if err := ValidateStringListNotEmpty("assignedScopes", o.AssignedScopes); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if err := ValidateTagsWithoutReservedPrefixes("associatedTags", o.AssociatedTags); err != nil {
 		errors = errors.Append(err)
 	}


### PR DESCRIPTION

closes aporeto-inc/aporeto#2584