### PR TITLE
new: Add support for Outbounds ACLs in Target Networks

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -266,9 +266,11 @@ func ValidateEnforcerProfile(enforcerProfile *EnforcerProfile) error {
 	// Validate Target Networks
 	for _, tn := range enforcerProfile.TargetNetworks {
 
-		cidr := strings.TrimLeft(tn, "!")
+		if strings.HasPrefix(tn, "!") {
+			tn = tn[1:]
+		}
 
-		_, _, err := net.ParseCIDR(cidr)
+		_, _, err := net.ParseCIDR(tn)
 		if err != nil {
 			return makeValidationError("targetNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
 		}

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -265,7 +265,10 @@ func ValidateEnforcerProfile(enforcerProfile *EnforcerProfile) error {
 
 	// Validate Target Networks
 	for _, tn := range enforcerProfile.TargetNetworks {
-		_, _, err := net.ParseCIDR(tn)
+
+		cidr := strings.TrimLeft(tn, "!")
+
+		_, _, err := net.ParseCIDR(cidr)
 		if err != nil {
 			return makeValidationError("targetNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
 		}

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -814,6 +814,14 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"valid target network with multiple NOT operator",
+			&EnforcerProfile{
+				Name:           "Valid target network",
+				TargetNetworks: []string{"!!10.0.0.0/8"},
+			},
+			true,
+		},
 
 		// Trusted CAs
 		{

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -815,7 +815,7 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			true,
 		},
 		{
-			"valid target network with multiple NOT operator",
+			"invalid target network with multiple NOT operator",
 			&EnforcerProfile{
 				Name:           "Valid target network",
 				TargetNetworks: []string{"!!10.0.0.0/8"},

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -791,6 +791,22 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			false,
 		},
 		{
+			"valid target network with NOT operator",
+			&EnforcerProfile{
+				Name:           "Valid target network",
+				TargetNetworks: []string{"!10.0.0.0/8"},
+			},
+			false,
+		},
+		{
+			"valid target networks with except condition operator",
+			&EnforcerProfile{
+				Name:           "Valid target network",
+				TargetNetworks: []string{"0.0.0.0/0", "!10.0.0.0/8"},
+			},
+			false,
+		},
+		{
 			"invalid target network",
 			&EnforcerProfile{
 				Name:           "Invalid target network",


### PR DESCRIPTION
This PR adds validation to support the NOT operator in the Target Networks.

> Reference: https://github.com/aporeto-inc/aporeto-devs/issues/29