### PR TITLE
fix: add validation for UDP target networks

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -276,6 +276,19 @@ func ValidateEnforcerProfile(enforcerProfile *EnforcerProfile) error {
 		}
 	}
 
+	// Validate Target UDP Networks
+	for _, tn := range enforcerProfile.TargetUDPNetworks {
+
+		if strings.HasPrefix(tn, "!") {
+			tn = tn[1:]
+		}
+
+		_, _, err := net.ParseCIDR(tn)
+		if err != nil {
+			return makeValidationError("targetUDPNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
+		}
+	}
+
 	// Validate trusted CAs
 	for i, ca := range enforcerProfile.TrustedCAs {
 		rest := []byte(ca)

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -781,7 +781,7 @@ func TestValidateEnforcerProfile(t *testing.T) {
 		enforcerprofile *EnforcerProfile
 		wantErr         bool
 	}{
-		// Invalid CIDR
+		// Target Networks
 		{
 			"valid target network",
 			&EnforcerProfile{
@@ -819,6 +819,47 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			&EnforcerProfile{
 				Name:           "Valid target network",
 				TargetNetworks: []string{"!!10.0.0.0/8"},
+			},
+			true,
+		},
+		// Target UDP Networks
+		{
+			"valid target UDP network",
+			&EnforcerProfile{
+				Name:              "Valid target UDP network",
+				TargetUDPNetworks: []string{"0.0.0.0/0"},
+			},
+			false,
+		},
+		{
+			"valid target UDP network with NOT operator",
+			&EnforcerProfile{
+				Name:              "Valid target UDP network",
+				TargetUDPNetworks: []string{"!10.0.0.0/8"},
+			},
+			false,
+		},
+		{
+			"valid target UDP networks with except condition operator",
+			&EnforcerProfile{
+				Name:              "Valid target UDP network",
+				TargetUDPNetworks: []string{"0.0.0.0/0", "!10.0.0.0/8"},
+			},
+			false,
+		},
+		{
+			"invalid target UDP network",
+			&EnforcerProfile{
+				Name:              "Invalid target UDP network",
+				TargetUDPNetworks: []string{"invalid"},
+			},
+			true,
+		},
+		{
+			"invalid target UDP network with multiple NOT operator",
+			&EnforcerProfile{
+				Name:              "Valid target UDP network",
+				TargetUDPNetworks: []string{"!!10.0.0.0/8"},
 			},
 			true,
 		},


### PR DESCRIPTION
Same PR as this morning, but this time for UDP Target Networks.

For some reasons, we didn't have any test on this property.