### PR TITLE
Support NOT operator in excluded networks

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -289,6 +289,19 @@ func ValidateEnforcerProfile(enforcerProfile *EnforcerProfile) error {
 		}
 	}
 
+	// Validate Excluded Networks
+	for _, tn := range enforcerProfile.ExcludedNetworks {
+
+		if strings.HasPrefix(tn, "!") {
+			tn = tn[1:]
+		}
+
+		_, _, err := net.ParseCIDR(tn)
+		if err != nil {
+			return makeValidationError("excludedNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
+		}
+	}
+
 	// Validate trusted CAs
 	for i, ca := range enforcerProfile.TrustedCAs {
 		rest := []byte(ca)

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -862,7 +862,47 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			},
 			true,
 		},
-
+		// Excluded Networks
+		{
+			"valid excluded network",
+			&EnforcerProfile{
+				Name:             "Valid excluded network",
+				ExcludedNetworks: []string{"0.0.0.0/0"},
+			},
+			false,
+		},
+		{
+			"valid excluded network with NOT operator",
+			&EnforcerProfile{
+				Name:             "Valid excluded network",
+				ExcludedNetworks: []string{"!10.0.0.0/8"},
+			},
+			false,
+		},
+		{
+			"valid excluded networks with except condition operator",
+			&EnforcerProfile{
+				Name:             "Valid excluded network",
+				ExcludedNetworks: []string{"0.0.0.0/0", "!10.0.0.0/8"},
+			},
+			false,
+		},
+		{
+			"invalid excluded network",
+			&EnforcerProfile{
+				Name:             "Invalid excluded network",
+				ExcludedNetworks: []string{"invalid"},
+			},
+			true,
+		},
+		{
+			"invalid excluded network with multiple NOT operator",
+			&EnforcerProfile{
+				Name:             "Valid excluded network",
+				ExcludedNetworks: []string{"!!10.0.0.0/8"},
+			},
+			true,
+		},
 		// Trusted CAs
 		{
 			"valid trusted CA",


### PR DESCRIPTION
Not operator needs to be supported in excluded networks as well (See [comment](https://github.com/aporeto-inc/aporeto-devs/issues/10#issuecomment-610731675))

This PR does the same check for TCP and UDP target networks
> Related to https://github.com/aporeto-inc/gaia/pull/464