### PR TITLE
fix: improve CIDR validation in enforcer profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ artifacts
 .idea/*
 values_codecgen.go
 .DS_Store
+.vscode

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -14,6 +14,7 @@ import (
 
 	"go.aporeto.io/elemental"
 	"go.aporeto.io/gaia/constants"
+	"go.aporeto.io/gaia/netutils"
 	"go.aporeto.io/gaia/portutils"
 	"go.aporeto.io/gaia/protocols"
 	"gopkg.in/yaml.v2"
@@ -263,43 +264,16 @@ func makeValidationError(attribute string, message string) elemental.Error {
 // ValidateEnforcerProfile validates a an enforcer profile.
 func ValidateEnforcerProfile(enforcerProfile *EnforcerProfile) error {
 
-	// Validate Target Networks
-	for _, tn := range enforcerProfile.TargetNetworks {
-
-		if strings.HasPrefix(tn, "!") {
-			tn = tn[1:]
-		}
-
-		_, _, err := net.ParseCIDR(tn)
-		if err != nil {
-			return makeValidationError("targetNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
-		}
+	if err := netutils.ValidateCIDRs(enforcerProfile.TargetNetworks); err != nil {
+		return makeValidationError("targetNetworks", err.Error())
 	}
 
-	// Validate Target UDP Networks
-	for _, tn := range enforcerProfile.TargetUDPNetworks {
-
-		if strings.HasPrefix(tn, "!") {
-			tn = tn[1:]
-		}
-
-		_, _, err := net.ParseCIDR(tn)
-		if err != nil {
-			return makeValidationError("targetUDPNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
-		}
+	if err := netutils.ValidateCIDRs(enforcerProfile.TargetUDPNetworks); err != nil {
+		return makeValidationError("targetUDPNetworks", err.Error())
 	}
 
-	// Validate Excluded Networks
-	for _, tn := range enforcerProfile.ExcludedNetworks {
-
-		if strings.HasPrefix(tn, "!") {
-			tn = tn[1:]
-		}
-
-		_, _, err := net.ParseCIDR(tn)
-		if err != nil {
-			return makeValidationError("excludedNetworks", fmt.Sprintf("%s is not a valid CIDR", tn))
-		}
+	if err := netutils.ValidateCIDRs(enforcerProfile.ExcludedNetworks); err != nil {
+		return makeValidationError("excludedNetworks", err.Error())
 	}
 
 	// Validate trusted CAs

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -790,14 +790,6 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			false,
 		},
 		{
-			"valid target network with NOT operator",
-			&EnforcerProfile{
-				Name:           "Valid target network",
-				TargetNetworks: []string{"!10.0.0.0/8"},
-			},
-			false,
-		},
-		{
 			"valid target networks with except condition operator",
 			&EnforcerProfile{
 				Name:           "Valid target network",
@@ -821,20 +813,20 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"valid target network with NOT operator",
+			&EnforcerProfile{
+				Name:           "Valid target network",
+				TargetNetworks: []string{"!10.0.0.0/8"},
+			},
+			true,
+		},
 		// Target UDP Networks
 		{
 			"valid target UDP network",
 			&EnforcerProfile{
 				Name:              "Valid target UDP network",
 				TargetUDPNetworks: []string{"0.0.0.0/0"},
-			},
-			false,
-		},
-		{
-			"valid target UDP network with NOT operator",
-			&EnforcerProfile{
-				Name:              "Valid target UDP network",
-				TargetUDPNetworks: []string{"!10.0.0.0/8"},
 			},
 			false,
 		},
@@ -862,20 +854,20 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"valid target UDP network with NOT operator",
+			&EnforcerProfile{
+				Name:              "Valid target UDP network",
+				TargetUDPNetworks: []string{"!10.0.0.0/8"},
+			},
+			true,
+		},
 		// Excluded Networks
 		{
 			"valid excluded network",
 			&EnforcerProfile{
 				Name:             "Valid excluded network",
 				ExcludedNetworks: []string{"0.0.0.0/0"},
-			},
-			false,
-		},
-		{
-			"valid excluded network with NOT operator",
-			&EnforcerProfile{
-				Name:             "Valid excluded network",
-				ExcludedNetworks: []string{"!10.0.0.0/8"},
 			},
 			false,
 		},
@@ -900,6 +892,14 @@ func TestValidateEnforcerProfile(t *testing.T) {
 			&EnforcerProfile{
 				Name:             "Valid excluded network",
 				ExcludedNetworks: []string{"!!10.0.0.0/8"},
+			},
+			true,
+		},
+		{
+			"valid excluded network with NOT operator",
+			&EnforcerProfile{
+				Name:             "Valid excluded network",
+				ExcludedNetworks: []string{"!10.0.0.0/8"},
 			},
 			true,
 		},

--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -1,0 +1,68 @@
+package netutils
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// prefixIsContained is used to check if an IP is included in a list of CIDRs
+func prefixIsContained(cidrs []*net.IPNet, ip net.IP) bool {
+
+	for _, c := range cidrs {
+		if c.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseCIDRs converts a list of string to list of net.IPNet. Returns an error if it wasnt able to parse a CIDR
+func parseCIDRs(cidrs []string) ([]*net.IPNet, error) {
+
+	prefixes := []*net.IPNet{}
+	for _, s := range cidrs {
+		_, network, err := net.ParseCIDR(s)
+		if err != nil {
+			return nil, fmt.Errorf("%s is not a valid CIDR", s)
+		}
+		prefixes = append(prefixes, network)
+	}
+	return prefixes, nil
+}
+
+// ValidateCIDRs validates that the CIDRs provided as a set is valid
+func ValidateCIDRs(cidrs []string) error {
+
+	regular := []string{}
+	for _, s := range cidrs {
+		if strings.HasPrefix(s, "!") {
+			continue
+		}
+		regular = append(regular, s)
+	}
+
+	// Get regular prefixes
+	prefixes, err := parseCIDRs(regular)
+	if err != nil {
+		return err
+	}
+
+	// Parse and validate all not CIDRs are included in regular CIDRs
+	for _, s := range cidrs {
+		if !strings.HasPrefix(s, "!") {
+			continue
+		}
+		c := strings.TrimPrefix(s, "!")
+		ip, _, err := net.ParseCIDR(c)
+		if err != nil {
+			return fmt.Errorf("%s is not a valid CIDR", c)
+		}
+		if !prefixIsContained(prefixes, ip) {
+			return fmt.Errorf("%s is not contained in any CIDR", s)
+		}
+	}
+
+	return nil
+}

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -1,0 +1,119 @@
+package netutils
+
+import (
+	"net"
+	"testing"
+)
+
+func Test_prefixIsContained(t *testing.T) {
+	type args struct {
+		prefixes []string
+		ip       string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "basic test",
+			args: args{
+				prefixes: []string{"10.10.0.0/16", "0.0.0.0/0"},
+				ip:       "10.10.10.10/32",
+			},
+			want: true,
+		},
+		{
+			name: "basic test failure",
+			args: args{
+				prefixes: []string{},
+				ip:       "20.20.20.20/32",
+			},
+			want: false,
+		},
+		{
+			name: "multiple match test",
+			args: args{
+				prefixes: []string{"10.10.10.0/24", "10.10.0.0/16", "0.0.0.0/0"},
+				ip:       "10.10.10.10/32",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefixes, err := parseCIDRs(tt.args.prefixes)
+			if err != nil {
+				t.Errorf("err in test: %v", err)
+			}
+			ip, _, err := net.ParseCIDR(tt.args.ip)
+			if err != nil {
+				t.Errorf("err in test: %v", err)
+			}
+			if got := prefixIsContained(prefixes, ip); got != tt.want {
+				t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ValidateCIDRs(t *testing.T) {
+	type args struct {
+		cidrs []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "basic test",
+			args: args{
+				[]string{"10.10.10.10/32"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "basic inclusion test",
+			args: args{
+				[]string{"10.10.10.0/24", "!10.10.10.10/32"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "basic failure test",
+			args: args{
+				[]string{"!10.10.10.10/32"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "recursive test",
+			args: args{
+				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "0.0.0.0/0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "recursive fail test",
+			args: args{
+				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "recursive multiple not test",
+			args: args{
+				[]string{"!10.10.10.10/32", "!10.10.10.0/24", "!10.10.0.0/16", "!10.0.0.0/8", "0.0.0.0/0"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateCIDRs(tt.args.cidrs); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCIDRs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
_This PR will be backported in 3.14 for Outbound ACLs_

Introducing a `netutils` package to validate CIDR.

Usually, we are using `net.ParseCIDR` to validate a string.
Recently, we added the not operator in front of CIDR and the following example is no longer valid:

```
!10.0.0.0/8
```

Any `!` notation should be a subset of a non prefix CIDR. The following is valid:
```
0.0.0.0/0 !10.0.0.0/8
```