### PR TITLE
added validation on cidr mask validation

### DIFF
--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -8,13 +8,12 @@ import (
 
 // ipMaskContains is used to check if a mask's range contains another mask's range
 func ipMaskContains(mask1 net.IPMask, mask2 net.IPMask) bool {
-	for i := 0; i < len(mask1); i++ {
-		if mask1[i] > mask2[i] {
-			return false
-		}
+	ones1, size1 := mask1.Size()
+	ones2, size2 := mask2.Size()
+	if size1 != size2 {
+		return false // Dont compare IPv4 and IPv6
 	}
-
-	return true
+	return ones1 <= ones2
 }
 
 // prefixIsContained is used to check if a network is included in a list of CIDRs

--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -43,16 +43,16 @@ func parseCIDRs(cidrs []string) ([]*net.IPNet, error) {
 // ValidateCIDRs validates that the CIDRs provided as a set is valid
 func ValidateCIDRs(cidrs []string) error {
 
-	regular := []string{}
+	regulars := []string{}
 	for _, s := range cidrs {
 		if strings.HasPrefix(s, "!") {
 			continue
 		}
-		regular = append(regular, s)
+		regulars = append(regulars, s)
 	}
 
 	// Get regular prefixes
-	prefixes, err := parseCIDRs(regular)
+	prefixes, err := parseCIDRs(regulars)
 	if err != nil {
 		return err
 	}
@@ -63,6 +63,11 @@ func ValidateCIDRs(cidrs []string) error {
 			continue
 		}
 		c := strings.TrimPrefix(s, "!")
+		for _, regular := range regulars {
+			if regular == c {
+				return fmt.Errorf("%s can't be both included and excluded", c)
+			}
+		}
 		_, network, err := net.ParseCIDR(c)
 		if err != nil {
 			return fmt.Errorf("%s is not a valid CIDR", c)

--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -6,21 +6,19 @@ import (
 	"strings"
 )
 
-// ipMaskContains is used to check if a mask's range contains another mask's range
-func ipMaskContains(mask1 net.IPMask, mask2 net.IPMask) bool {
-	ones1, size1 := mask1.Size()
-	ones2, size2 := mask2.Size()
-	if size1 != size2 {
-		return false // Dont compare IPv4 and IPv6
-	}
-	return ones1 <= ones2
-}
-
-// prefixIsContained is used to check if a network is included in a list of CIDRs
+// prefixIsContained is used to check if an IP is included in a list of CIDRs
 func prefixIsContained(cidrs []*net.IPNet, network *net.IPNet) bool {
 
 	for _, c := range cidrs {
-		if c.Contains(network.IP) && ipMaskContains(c.Mask, network.Mask) {
+		if !c.Contains(network.IP) {
+			continue
+		}
+		ones1, size1 := c.Mask.Size()
+		ones2, size2 := network.Mask.Size()
+		if size1 != size2 {
+			continue
+		}
+		if ones1 <= ones2 {
 			return true
 		}
 	}
@@ -28,21 +26,18 @@ func prefixIsContained(cidrs []*net.IPNet, network *net.IPNet) bool {
 	return false
 }
 
-// parseCIDRs converts a list of string to list of net.IPNet in v4 and v6. Returns an error if it wasnt able to parse a CIDR
-func parseCIDRs(cidrs []string) (ipNetsV4 []*net.IPNet, ipNetsV6 []*net.IPNet, _ error) {
+// parseCIDRs converts a list of string to list of net.IPNet. Returns an error if it wasnt able to parse a CIDR
+func parseCIDRs(cidrs []string) ([]*net.IPNet, error) {
 
+	prefixes := []*net.IPNet{}
 	for _, s := range cidrs {
-		ip, network, err := net.ParseCIDR(s)
+		_, network, err := net.ParseCIDR(s)
 		if err != nil {
-			return ipNetsV4, ipNetsV6, fmt.Errorf("%s is not a valid CIDR", s)
+			return nil, err
 		}
-		if ipv4 := ip.To4(); ipv4 != nil {
-			ipNetsV4 = append(ipNetsV4, network)
-		} else if ipv6 := ip.To16(); ipv6 != nil {
-			ipNetsV6 = append(ipNetsV6, network)
-		}
+		prefixes = append(prefixes, network)
 	}
-	return ipNetsV4, ipNetsV6, nil
+	return prefixes, nil
 }
 
 // ValidateCIDRs validates that the CIDRs provided as a set is valid
@@ -57,7 +52,7 @@ func ValidateCIDRs(cidrs []string) error {
 	}
 
 	// Get regular prefixes
-	prefixesV4, prefixesV6, err := parseCIDRs(regular)
+	prefixes, err := parseCIDRs(regular)
 	if err != nil {
 		return err
 	}
@@ -68,18 +63,12 @@ func ValidateCIDRs(cidrs []string) error {
 			continue
 		}
 		c := strings.TrimPrefix(s, "!")
-		ip, network, err := net.ParseCIDR(c)
+		_, network, err := net.ParseCIDR(c)
 		if err != nil {
-			return fmt.Errorf("%s is not a valid CIDR", c)
+			return err
 		}
-		if ipv4 := ip.To4(); ipv4 != nil {
-			if !prefixIsContained(prefixesV4, network) {
-				return fmt.Errorf("%s is not contained in any CIDR", s)
-			}
-		} else if ipv6 := ip.To16(); ipv6 != nil {
-			if !prefixIsContained(prefixesV6, network) {
-				return fmt.Errorf("%s is not contained in any CIDR", s)
-			}
+		if !prefixIsContained(prefixes, network) {
+			return fmt.Errorf("prefix %s is not contained in any CIDR", s)
 		}
 	}
 

--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -33,7 +33,7 @@ func parseCIDRs(cidrs []string) ([]*net.IPNet, error) {
 	for _, s := range cidrs {
 		_, network, err := net.ParseCIDR(s)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%s is not a valid CIDR", s)
 		}
 		prefixes = append(prefixes, network)
 	}
@@ -65,7 +65,7 @@ func ValidateCIDRs(cidrs []string) error {
 		c := strings.TrimPrefix(s, "!")
 		_, network, err := net.ParseCIDR(c)
 		if err != nil {
-			return err
+			return fmt.Errorf("%s is not a valid CIDR", c)
 		}
 		if !prefixIsContained(prefixes, network) {
 			return fmt.Errorf("prefix %s is not contained in any CIDR", s)

--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	opInclude = "include"
-	opExclude = "exclude"
+	opInclude = "include" // default operation to include cidr in networks
+	opExclude = "exclude" // not include cidr when cidr string has the ! prefix
 )
 
 // cidr represents the cidr network to be included or excluded

--- a/netutils/cidr.go
+++ b/netutils/cidr.go
@@ -28,7 +28,7 @@ type cidr struct {
 func prefixIsContained(cidrs []*cidr, c *cidr) bool {
 
 	for _, pc := range cidrs {
-		if !pc.ipNet.Contains(c.ipNet.IP) {
+		if pc.op == opExclude || !pc.ipNet.Contains(c.ipNet.IP) {
 			continue
 		}
 		ones1, size1 := pc.ipNet.Mask.Size()
@@ -36,7 +36,7 @@ func prefixIsContained(cidrs []*cidr, c *cidr) bool {
 		if size1 != size2 {
 			continue
 		}
-		if ones1 < ones2 {
+		if ones1 <= ones2 {
 			return true
 		}
 	}
@@ -56,7 +56,7 @@ func hasDuplicates(cidrs []*cidr, c *cidr) bool {
 	return false
 }
 
-// parseCIDRs converts a list of string to list of cidr. Returns an error if it wasnt able to parse a CIDR
+// parseCIDRs converts a list of string to list of cidr. Returns an error if it wasnt able to parse a CIDR or there is duplication
 func parseCIDRs(addresses []string) ([]*cidr, error) {
 
 	cidrs := []*cidr{}
@@ -83,7 +83,7 @@ func parseCIDRs(addresses []string) ([]*cidr, error) {
 	return cidrs, nil
 }
 
-// ValidateCIDRs validates that the list of string provided as a set is valid CIDR set
+// ValidateCIDRs validates that the list of string provided as a set is a valid CIDR set
 func ValidateCIDRs(addresses []string) error {
 
 	cidrs, err := parseCIDRs(addresses)

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -122,9 +122,13 @@ func Test_prefixIsContained(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cidrs, err := parseCIDRs(tt.args.prefixes)
-			if err != nil {
-				t.Errorf("err in test: %v", err)
+			cidrs := []*cidr{}
+			for _, s := range tt.args.prefixes {
+				cidr, err := parseCIDR(s)
+				if err != nil {
+					t.Errorf("err in test: %v", err)
+				}
+				cidrs = append(cidrs, cidr)
 			}
 			_, network, err := net.ParseCIDR(tt.args.ip)
 			if err != nil {
@@ -147,6 +151,13 @@ func Test_ValidateCIDRs(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
+		{
+			name: "duplication in inclusion test",
+			args: args{
+				[]string{"0.0.0.0/0", "10.10.10.0/16", "10.10.10.0/16"},
+			},
+			wantErr: true,
+		},
 		{
 			name: "basic test",
 			args: args{
@@ -186,13 +197,6 @@ func Test_ValidateCIDRs(t *testing.T) {
 			name: "basic duplication test",
 			args: args{
 				[]string{"0.0.0.0/0", "10.10.10.0/16", "!10.10.10.0/16"},
-			},
-			wantErr: true,
-		},
-		{
-			name: "duplication in inclusion test",
-			args: args{
-				[]string{"0.0.0.0/0", "10.10.10.0/16", "10.10.10.0/16"},
 			},
 			wantErr: true,
 		},

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -39,6 +39,14 @@ func Test_prefixIsContained(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "cidr not contained test failure",
+			args: args{
+				prefixes: []string{"10.10.0.0/16"},
+				ip:       "10.10.0.0/8",
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -46,11 +54,11 @@ func Test_prefixIsContained(t *testing.T) {
 			if err != nil {
 				t.Errorf("err in test: %v", err)
 			}
-			ip, _, err := net.ParseCIDR(tt.args.ip)
+			_, network, err := net.ParseCIDR(tt.args.ip)
 			if err != nil {
 				t.Errorf("err in test: %v", err)
 			}
-			if got := prefixIsContained(prefixes, ip); got != tt.want {
+			if got := prefixIsContained(prefixes, network); got != tt.want {
 				t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
 			}
 		})
@@ -84,6 +92,13 @@ func Test_ValidateCIDRs(t *testing.T) {
 			name: "basic failure test",
 			args: args{
 				[]string{"!10.10.10.10/32"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "basic cidr not contained failure test",
+			args: args{
+				[]string{"10.10.10.0/16", "!10.10.10.10/8"},
 			},
 			wantErr: true,
 		},

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -341,14 +341,14 @@ func Test_ValidateCIDRs(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "both IPv4 and IPv6 IPv4 with IPv4 not contained failure test",
+			name: "both IPv4 and IPv6 with IPv4 not contained failure test",
 			args: args{
 				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16", "::/0"},
 			},
 			wantErr: true,
 		},
 		{
-			name: "both IPv4 and IPv6 IPv4 with IPv6 not contained failure test",
+			name: "both IPv4 and IPv6 with IPv6 not contained failure test",
 			args: args{
 				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "0.0.0.0/0", "2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16"},
 			},

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -1,142 +1,8 @@
 package netutils
 
 import (
-	"net"
 	"testing"
 )
-
-func Test_prefixIsContained(t *testing.T) {
-	type args struct {
-		prefixes []string
-		ip       string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "basic test",
-			args: args{
-				prefixes: []string{"0.0.0.0/0"},
-				ip:       "0.0.0.0/0",
-			},
-			want: true,
-		},
-		{
-			name: "basic test 2",
-			args: args{
-				prefixes: []string{"10.10.0.0/16", "0.0.0.0/0"},
-				ip:       "10.10.10.10/32",
-			},
-			want: true,
-		},
-		{
-			name: "basic test failure",
-			args: args{
-				prefixes: []string{},
-				ip:       "20.20.20.20/32",
-			},
-			want: false,
-		},
-		{
-			name: "multiple match test",
-			args: args{
-				prefixes: []string{"10.10.10.0/24", "10.10.0.0/16", "0.0.0.0/0"},
-				ip:       "10.10.10.10/32",
-			},
-			want: true,
-		},
-		{
-			name: "cidr not contained test failure",
-			args: args{
-				prefixes: []string{"10.10.0.0/16"},
-				ip:       "10.10.0.0/8",
-			},
-			want: false,
-		},
-		{
-			name: "basic test IPv6",
-			args: args{
-				prefixes: []string{"::/0"},
-				ip:       "::/0",
-			},
-			want: true,
-		},
-		{
-			name: "basic test IPv6 2",
-			args: args{
-				prefixes: []string{"2001:db8::/64", "::/0"},
-				ip:       "2001:db8::/128",
-			},
-			want: true,
-		},
-		{
-			name: "basic test failure IPv6",
-			args: args{
-				prefixes: []string{},
-				ip:       "2001:db8::/128",
-			},
-			want: false,
-		},
-		{
-			name: "multiple match test IPv6",
-			args: args{
-				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0"},
-				ip:       "2001:db8::/128",
-			},
-			want: true,
-		},
-		{
-			name: "cidr not contained test failure IPv6",
-			args: args{
-				prefixes: []string{"2001:db8::/64"},
-				ip:       "2001:db8::/32",
-			},
-			want: false,
-		},
-		{
-			name: "mix of both IPv4 and IPv6 test",
-			args: args{
-				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0", "10.10.10.0/24", "10.10.0.0/16", "0.0.0.0/0"},
-				ip:       "2001:db8::/128",
-			},
-			want: true,
-		},
-		{
-			name: "IPv6 not contained in IPv4 cidrs failure test",
-			args: args{
-				prefixes: []string{"10.10.10.0/24", "10.10.0.0/16", "0.0.0.0/0"},
-				ip:       "2001:db8::/128",
-			},
-			want: false,
-		},
-		{
-			name: "IPv4 not contained in IPv6 cidrs failure test",
-			args: args{
-				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0"},
-				ip:       "10.10.10.10/32",
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			prefixes, err := parseCIDRs(tt.args.prefixes)
-			if err != nil {
-				t.Errorf("err in test: %v", err)
-			}
-			_, network, err := net.ParseCIDR(tt.args.ip)
-			if err != nil {
-				t.Errorf("err in test: %v", err)
-			}
-
-			if got := prefixIsContained(prefixes, network); got != tt.want {
-				t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
 func Test_ValidateCIDRs(t *testing.T) {
 	type args struct {
@@ -162,6 +28,20 @@ func Test_ValidateCIDRs(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "basic format failure test",
+			args: args{
+				[]string{"!10.10.10.10/ss"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "basic format failure test 2",
+			args: args{
+				[]string{"!10.10.10/24"},
+			},
+			wantErr: true,
+		},
+		{
 			name: "basic cidr not contained failure test",
 			args: args{
 				[]string{"10.10.10.0/16", "!10.10.10.10/8"},
@@ -172,6 +52,34 @@ func Test_ValidateCIDRs(t *testing.T) {
 			name: "basic duplication test",
 			args: args{
 				[]string{"0.0.0.0/0", "10.10.10.0/16", "!10.10.10.0/16"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication in inclusion test",
+			args: args{
+				[]string{"0.0.0.0/0", "10.10.10.0/16", "10.10.10.0/16"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication in exclusion test",
+			args: args{
+				[]string{"0.0.0.0/0", "!10.10.10.0/16", "10.10.10.0/16"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication in inclusion with different IP test",
+			args: args{
+				[]string{"0.0.0.0/0", "10.10.10.2/16", "10.10.10.4/16"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication in exclusion with different IP test",
+			args: args{
+				[]string{"0.0.0.0/0", "!10.10.10.2/16", "10.10.10.4/16"},
 			},
 			wantErr: true,
 		},
@@ -197,11 +105,18 @@ func Test_ValidateCIDRs(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "basic test IPv6",
+			name: "basic format failure test IPv6",
 			args: args{
-				[]string{"2001:db8::/128"},
+				[]string{"2001:db8::/ss"},
 			},
-			wantErr: false,
+			wantErr: true,
+		},
+		{
+			name: "basic format failure test 2 IPv6",
+			args: args{
+				[]string{"2001:db8:/64"},
+			},
+			wantErr: true,
 		},
 		{
 			name: "basic inclusion test IPv6",
@@ -228,6 +143,34 @@ func Test_ValidateCIDRs(t *testing.T) {
 			name: "basic duplication test IPv6",
 			args: args{
 				[]string{"::/0", "2001:db8::/64", "!2001:db8::/64"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication test in inclusion IPv6",
+			args: args{
+				[]string{"::/0", "2001:db8::/64", "2001:db8::/64"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication test in exclusion IPv6",
+			args: args{
+				[]string{"::/0", "!2001:db8::/64", "!2001:db8::/64"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication test in inclusion with different IP IPv6",
+			args: args{
+				[]string{"::/0", "2001:db8::8888/64", "2001:db8::/64"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplication test in inclusion with different IP IPv6",
+			args: args{
+				[]string{"::/0", "!2001:db8::8888/64", "!2001:db8::/64"},
 			},
 			wantErr: true,
 		},

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -47,19 +47,82 @@ func Test_prefixIsContained(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "basic test IPv6",
+			args: args{
+				prefixes: []string{"2001:db8::/64", "::/0"},
+				ip:       "2001:db8::/128",
+			},
+			want: true,
+		},
+		{
+			name: "basic test failure",
+			args: args{
+				prefixes: []string{},
+				ip:       "2001:db8::/128",
+			},
+			want: false,
+		},
+		{
+			name: "multiple match test",
+			args: args{
+				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0"},
+				ip:       "2001:db8::/128",
+			},
+			want: true,
+		},
+		{
+			name: "cidr not contained test failure",
+			args: args{
+				prefixes: []string{"2001:db8::/64"},
+				ip:       "2001:db8::/32",
+			},
+			want: false,
+		},
+		{
+			name: "mix of both IPv4 and IPv6 test",
+			args: args{
+				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0", "10.10.10.0/24", "10.10.0.0/16", "0.0.0.0/0"},
+				ip:       "2001:db8::/128",
+			},
+			want: true,
+		},
+		{
+			name: "IPv6 not contained in IPv4 cidrs failure test",
+			args: args{
+				prefixes: []string{"10.10.10.0/24", "10.10.0.0/16", "0.0.0.0/0"},
+				ip:       "2001:db8::/128",
+			},
+			want: false,
+		},
+		{
+			name: "IPv4 not contained in IPv6 cidrs failure test",
+			args: args{
+				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0"},
+				ip:       "10.10.10.10/32",
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefixes, err := parseCIDRs(tt.args.prefixes)
+			prefixesV4, prefixesV6, err := parseCIDRs(tt.args.prefixes)
 			if err != nil {
 				t.Errorf("err in test: %v", err)
 			}
-			_, network, err := net.ParseCIDR(tt.args.ip)
+			ip, network, err := net.ParseCIDR(tt.args.ip)
 			if err != nil {
 				t.Errorf("err in test: %v", err)
 			}
-			if got := prefixIsContained(prefixes, network); got != tt.want {
-				t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
+
+			if ipv4 := ip.To4(); ipv4 != nil {
+				if got := prefixIsContained(prefixesV4, network); got != tt.want {
+					t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
+				}
+			} else if ipv6 := ip.To16(); ipv6 != nil {
+				if got := prefixIsContained(prefixesV6, network); got != tt.want {
+					t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
+				}
 			}
 		})
 	}
@@ -122,6 +185,69 @@ func Test_ValidateCIDRs(t *testing.T) {
 				[]string{"!10.10.10.10/32", "!10.10.10.0/24", "!10.10.0.0/16", "!10.0.0.0/8", "0.0.0.0/0"},
 			},
 			wantErr: false,
+		},
+		{
+			name: "basic test IPv6",
+			args: args{
+				[]string{"2001:db8::/128"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "basic inclusion test IPv6",
+			args: args{
+				[]string{"2001:db8::/64", "!2001:db8::/128"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "basic failure test IPv6",
+			args: args{
+				[]string{"!2001:db8::/128"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "basic cidr not contained failure test IPv6",
+			args: args{
+				[]string{"2001:db8::/64", "!2001:db8::/32"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "recursive test IPv6",
+			args: args{
+				[]string{"2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16", "::/0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "recursive fail test IPv6",
+			args: args{
+				[]string{"2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "recursive multiple not test IPv6",
+			args: args{
+				[]string{"!2001:db8::/128", "!2001:db8::/64", "!2001:db8::/32", "!2001:db8::/16", "::/0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "both IPv4 and IPv6 test",
+			args: args{
+				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "0.0.0.0/0", "2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16", "::/0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "both IPv4 and IPv6 IPv4 not contained failure test",
+			args: args{
+				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16", "::/0"},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -155,13 +155,6 @@ func Test_ValidateCIDRs(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "basic inclusion test",
-			args: args{
-				[]string{"10.10.10.0/24", "!10.10.10.10/32"},
-			},
-			wantErr: false,
-		},
-		{
 			name: "basic failure test",
 			args: args{
 				[]string{"!10.10.10.10/32"},
@@ -172,6 +165,13 @@ func Test_ValidateCIDRs(t *testing.T) {
 			name: "basic cidr not contained failure test",
 			args: args{
 				[]string{"10.10.10.0/16", "!10.10.10.10/8"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "basic duplication test",
+			args: args{
+				[]string{"0.0.0.0/0", "10.10.10.0/16", "!10.10.10.0/16"},
 			},
 			wantErr: true,
 		},
@@ -221,6 +221,13 @@ func Test_ValidateCIDRs(t *testing.T) {
 			name: "basic cidr not contained failure test IPv6",
 			args: args{
 				[]string{"2001:db8::/64", "!2001:db8::/32"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "basic duplication test IPv6",
+			args: args{
+				[]string{"::/0", "2001:db8::/64", "!2001:db8::/64"},
 			},
 			wantErr: true,
 		},

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -18,6 +18,14 @@ func Test_prefixIsContained(t *testing.T) {
 		{
 			name: "basic test",
 			args: args{
+				prefixes: []string{"0.0.0.0/0"},
+				ip:       "0.0.0.0/0",
+			},
+			want: true,
+		},
+		{
+			name: "basic test 2",
+			args: args{
 				prefixes: []string{"10.10.0.0/16", "0.0.0.0/0"},
 				ip:       "10.10.10.10/32",
 			},
@@ -50,13 +58,21 @@ func Test_prefixIsContained(t *testing.T) {
 		{
 			name: "basic test IPv6",
 			args: args{
+				prefixes: []string{"::/0"},
+				ip:       "::/0",
+			},
+			want: true,
+		},
+		{
+			name: "basic test IPv6 2",
+			args: args{
 				prefixes: []string{"2001:db8::/64", "::/0"},
 				ip:       "2001:db8::/128",
 			},
 			want: true,
 		},
 		{
-			name: "basic test failure",
+			name: "basic test failure IPv6",
 			args: args{
 				prefixes: []string{},
 				ip:       "2001:db8::/128",
@@ -64,7 +80,7 @@ func Test_prefixIsContained(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "multiple match test",
+			name: "multiple match test IPv6",
 			args: args{
 				prefixes: []string{"2001:db8::/64", "2001:db8::/32", "::/0"},
 				ip:       "2001:db8::/128",
@@ -72,7 +88,7 @@ func Test_prefixIsContained(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "cidr not contained test failure",
+			name: "cidr not contained test failure IPv6",
 			args: args{
 				prefixes: []string{"2001:db8::/64"},
 				ip:       "2001:db8::/32",

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -259,9 +259,16 @@ func Test_ValidateCIDRs(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "both IPv4 and IPv6 IPv4 not contained failure test",
+			name: "both IPv4 and IPv6 IPv4 with IPv4 not contained failure test",
 			args: args{
 				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16", "::/0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "both IPv4 and IPv6 IPv4 with IPv6 not contained failure test",
+			args: args{
+				[]string{"10.10.10.10/32", "!10.10.10.0/24", "10.10.0.0/16", "!10.0.0.0/8", "0.0.0.0/0", "2001:db8::/128", "!2001:db8::/64", "2001:db8::/32", "!2001:db8::/16"},
 			},
 			wantErr: true,
 		},

--- a/netutils/cidr_test.go
+++ b/netutils/cidr_test.go
@@ -122,23 +122,17 @@ func Test_prefixIsContained(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefixesV4, prefixesV6, err := parseCIDRs(tt.args.prefixes)
+			prefixes, err := parseCIDRs(tt.args.prefixes)
 			if err != nil {
 				t.Errorf("err in test: %v", err)
 			}
-			ip, network, err := net.ParseCIDR(tt.args.ip)
+			_, network, err := net.ParseCIDR(tt.args.ip)
 			if err != nil {
 				t.Errorf("err in test: %v", err)
 			}
 
-			if ipv4 := ip.To4(); ipv4 != nil {
-				if got := prefixIsContained(prefixesV4, network); got != tt.want {
-					t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
-				}
-			} else if ipv6 := ip.To16(); ipv6 != nil {
-				if got := prefixIsContained(prefixesV6, network); got != tt.want {
-					t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
-				}
+			if got := prefixIsContained(prefixes, network); got != tt.want {
+				t.Errorf("prefixIsContained() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
 - Added validation on cases where cidr is not respecting the correct format and masks are not contained.
- Added check on network being both included and excluded
 - Added support for IPv6

Fixes: aporeto-inc/aporeto-devs#113